### PR TITLE
Add VS Code debugging and workspace configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-azuretools.vscode-docker"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Iniciar aplicación PequeLog",
+            "skipFiles": ["<node_internals>/**"],
+            "runtimeExecutable": "npm",
+            "runtimeArgs": ["run", "dev"],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal",
+            "preLaunchTask": "npm: dev",
+            "env": {
+                "NODE_ENV": "development"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "editor.formatOnSave": true,
+    "files.exclude": {
+        "**/.DS_Store": true,
+        "**/node_modules": true,
+        "**/.next": true
+    },
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/.next": true
+    },
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "eslint.format.enable": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "dev",
+            "label": "npm: dev",
+            "detail": "Inicia el servidor de desarrollo de PequeLog",
+            "problemMatcher": [],
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# pequelog
+# PequeLog
+
+Este repositorio incluye configuraciones básicas de Visual Studio Code para iniciar el servidor de desarrollo mediante `npm run dev`, depurar la aplicación y mantener un estilo de código consistente.
+
+## VS Code
+
+- **launch.json**: inicia la depuración ejecutando el script `npm run dev`.
+- **tasks.json**: define la tarea `npm: dev` que se usa como pre-tarea para la depuración.
+- **settings.json**: activa el formateo automático y la integración con ESLint y Prettier.
+- **extensions.json**: recomienda extensiones útiles para trabajar en el proyecto.
+
+Ajusta los scripts o las rutas según evolucione la aplicación.


### PR DESCRIPTION
## Summary
- add a VS Code launch configuration to debug the app via `npm run dev`
- define matching workspace tasks, settings, and extension recommendations
- document the available editor tooling in the README

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68e18377c26483329313c7097a079eb0