### PR TITLE
feat: add quick actions carousel and highlights

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -58,12 +58,37 @@
   },
   "babyHomePhotoPlaceholder": "No photo",
   "babyHomeActionsTitle": "Quick actions",
+  "babyHomeHighlightsTitle": "Last key moments",
+  "babyHomeHighlightsFeed": "Last bottle",
+  "babyHomeHighlightsDiaper": "Last diaper change",
+  "babyHomeHighlightsBath": "Last bath",
+  "babyHomeHighlightsVomit": "Last spit up",
+  "babyHomeHighlightsNoData": "No records yet",
+  "babyHomeHighlightsEntry": "{date} at {time} · {elapsed} ago",
+  "@babyHomeHighlightsEntry": {
+    "placeholders": {
+      "date": {},
+      "time": {},
+      "elapsed": {}
+    }
+  },
   "babyHomeMenuEdit": "Edit baby",
   "babyHomeMenuSettings": "Settings",
   "babyActionFeed": "Log feed",
   "babyActionBath": "Log bath",
   "babyActionVomited": "Log spit up",
   "babyActionDiaper": "Log diaper",
+  "babyActionHistory": "History",
+  "babyActionStatistics": "Statistics",
+  "babyActionAskPediatrician": "Ask pediatrician",
+  "babyActionMedicalAgenda": "Medical agenda",
+  "babyActionGrowth": "Growth",
+  "babyHomeFeatureComingSoon": "{feature} will be available soon.",
+  "@babyHomeFeatureComingSoon": {
+    "placeholders": {
+      "feature": {}
+    }
+  },
   "babyActionPlaceholderDescription": "You'll be able to record this activity very soon.",
   "actionDateLabel": "Date",
   "actionDateHint": "Select the day",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -58,12 +58,37 @@
   },
   "babyHomePhotoPlaceholder": "Sin foto",
   "babyHomeActionsTitle": "Acciones rápidas",
+  "babyHomeHighlightsTitle": "Últimos momentos clave",
+  "babyHomeHighlightsFeed": "Último biberón",
+  "babyHomeHighlightsDiaper": "Última caca",
+  "babyHomeHighlightsBath": "Último baño",
+  "babyHomeHighlightsVomit": "Último vómito",
+  "babyHomeHighlightsNoData": "Sin registros aún",
+  "babyHomeHighlightsEntry": "{date} a las {time} · hace {elapsed}",
+  "@babyHomeHighlightsEntry": {
+    "placeholders": {
+      "date": {},
+      "time": {},
+      "elapsed": {}
+    }
+  },
   "babyHomeMenuEdit": "Editar bebé",
   "babyHomeMenuSettings": "Configuración",
   "babyActionFeed": "Registrar toma",
   "babyActionBath": "Registrar baño",
   "babyActionVomited": "Registrar vómito",
   "babyActionDiaper": "Registrar caca",
+  "babyActionHistory": "Historial",
+  "babyActionStatistics": "Estadísticas",
+  "babyActionAskPediatrician": "Preguntas al pediatra",
+  "babyActionMedicalAgenda": "Agenda médica",
+  "babyActionGrowth": "Crecimiento",
+  "babyHomeFeatureComingSoon": "La sección {feature} estará disponible pronto.",
+  "@babyHomeFeatureComingSoon": {
+    "placeholders": {
+      "feature": {}
+    }
+  },
   "babyActionPlaceholderDescription": "Muy pronto podrás registrar esta actividad con todo detalle.",
   "actionDateLabel": "Fecha",
   "actionDateHint": "Selecciona el día",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -350,6 +350,48 @@ abstract class AppLocalizations {
   /// **'Acciones rápidas'**
   String get babyHomeActionsTitle;
 
+  /// No description provided for @babyHomeHighlightsTitle.
+  ///
+  /// In es, this message translates to:
+  /// **'Últimos momentos clave'**
+  String get babyHomeHighlightsTitle;
+
+  /// No description provided for @babyHomeHighlightsFeed.
+  ///
+  /// In es, this message translates to:
+  /// **'Último biberón'**
+  String get babyHomeHighlightsFeed;
+
+  /// No description provided for @babyHomeHighlightsDiaper.
+  ///
+  /// In es, this message translates to:
+  /// **'Última caca'**
+  String get babyHomeHighlightsDiaper;
+
+  /// No description provided for @babyHomeHighlightsBath.
+  ///
+  /// In es, this message translates to:
+  /// **'Último baño'**
+  String get babyHomeHighlightsBath;
+
+  /// No description provided for @babyHomeHighlightsVomit.
+  ///
+  /// In es, this message translates to:
+  /// **'Último vómito'**
+  String get babyHomeHighlightsVomit;
+
+  /// No description provided for @babyHomeHighlightsNoData.
+  ///
+  /// In es, this message translates to:
+  /// **'Sin registros aún'**
+  String get babyHomeHighlightsNoData;
+
+  /// No description provided for @babyHomeHighlightsEntry.
+  ///
+  /// In es, this message translates to:
+  /// **'{date} a las {time} · hace {elapsed}'**
+  String babyHomeHighlightsEntry(Object date, Object time, Object elapsed);
+
   /// No description provided for @babyHomeMenuEdit.
   ///
   /// In es, this message translates to:
@@ -385,6 +427,42 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'Registrar caca'**
   String get babyActionDiaper;
+
+  /// No description provided for @babyActionHistory.
+  ///
+  /// In es, this message translates to:
+  /// **'Historial'**
+  String get babyActionHistory;
+
+  /// No description provided for @babyActionStatistics.
+  ///
+  /// In es, this message translates to:
+  /// **'Estadísticas'**
+  String get babyActionStatistics;
+
+  /// No description provided for @babyActionAskPediatrician.
+  ///
+  /// In es, this message translates to:
+  /// **'Preguntas al pediatra'**
+  String get babyActionAskPediatrician;
+
+  /// No description provided for @babyActionMedicalAgenda.
+  ///
+  /// In es, this message translates to:
+  /// **'Agenda médica'**
+  String get babyActionMedicalAgenda;
+
+  /// No description provided for @babyActionGrowth.
+  ///
+  /// In es, this message translates to:
+  /// **'Crecimiento'**
+  String get babyActionGrowth;
+
+  /// No description provided for @babyHomeFeatureComingSoon.
+  ///
+  /// In es, this message translates to:
+  /// **'La sección {feature} estará disponible pronto.'**
+  String babyHomeFeatureComingSoon(Object feature);
 
   /// No description provided for @babyActionPlaceholderDescription.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -143,6 +143,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get babyHomeActionsTitle => 'Quick actions';
 
   @override
+  String get babyHomeHighlightsTitle => 'Last key moments';
+
+  @override
+  String get babyHomeHighlightsFeed => 'Last bottle';
+
+  @override
+  String get babyHomeHighlightsDiaper => 'Last diaper change';
+
+  @override
+  String get babyHomeHighlightsBath => 'Last bath';
+
+  @override
+  String get babyHomeHighlightsVomit => 'Last spit up';
+
+  @override
+  String get babyHomeHighlightsNoData => 'No records yet';
+
+  @override
+  String babyHomeHighlightsEntry(Object date, Object time, Object elapsed) {
+    return '$date at $time · $elapsed ago';
+  }
+
+  @override
   String get babyHomeMenuEdit => 'Edit baby';
 
   @override
@@ -159,6 +182,26 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get babyActionDiaper => 'Log diaper';
+
+  @override
+  String get babyActionHistory => 'History';
+
+  @override
+  String get babyActionStatistics => 'Statistics';
+
+  @override
+  String get babyActionAskPediatrician => 'Ask pediatrician';
+
+  @override
+  String get babyActionMedicalAgenda => 'Medical agenda';
+
+  @override
+  String get babyActionGrowth => 'Growth';
+
+  @override
+  String babyHomeFeatureComingSoon(Object feature) {
+    return '$feature will be available soon.';
+  }
 
   @override
   String get babyActionPlaceholderDescription =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -143,6 +143,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get babyHomeActionsTitle => 'Acciones rápidas';
 
   @override
+  String get babyHomeHighlightsTitle => 'Últimos momentos clave';
+
+  @override
+  String get babyHomeHighlightsFeed => 'Último biberón';
+
+  @override
+  String get babyHomeHighlightsDiaper => 'Última caca';
+
+  @override
+  String get babyHomeHighlightsBath => 'Último baño';
+
+  @override
+  String get babyHomeHighlightsVomit => 'Último vómito';
+
+  @override
+  String get babyHomeHighlightsNoData => 'Sin registros aún';
+
+  @override
+  String babyHomeHighlightsEntry(Object date, Object time, Object elapsed) {
+    return '$date a las $time · hace $elapsed';
+  }
+
+  @override
   String get babyHomeMenuEdit => 'Editar bebé';
 
   @override
@@ -159,6 +182,26 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get babyActionDiaper => 'Registrar caca';
+
+  @override
+  String get babyActionHistory => 'Historial';
+
+  @override
+  String get babyActionStatistics => 'Estadísticas';
+
+  @override
+  String get babyActionAskPediatrician => 'Preguntas al pediatra';
+
+  @override
+  String get babyActionMedicalAgenda => 'Agenda médica';
+
+  @override
+  String get babyActionGrowth => 'Crecimiento';
+
+  @override
+  String babyHomeFeatureComingSoon(Object feature) {
+    return 'La sección $feature estará disponible pronto.';
+  }
 
   @override
   String get babyActionPlaceholderDescription =>

--- a/lib/presentation/features/startup/baby_home_screen.dart
+++ b/lib/presentation/features/startup/baby_home_screen.dart
@@ -148,32 +148,19 @@ class BabyHomeScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 16),
-            Wrap(
-              spacing: 12,
-              runSpacing: 12,
-              children: [
-                _ActionButton(
-                  icon: Icons.local_drink_outlined,
-                  tooltip: l10n.babyActionFeed,
-                  onTap: () => _openFeedAction(context),
-                ),
-                _ActionButton(
-                  icon: Icons.bathtub_outlined,
-                  tooltip: l10n.babyActionBath,
-                  onTap: () => _openBathAction(context),
-                ),
-                _ActionButton(
-                  icon: Icons.sick_outlined,
-                  tooltip: l10n.babyActionVomited,
-                  onTap: () => _openVomitAction(context),
-                ),
-                _ActionButton(
-                  icon: Icons.baby_changing_station,
-                  tooltip: l10n.babyActionDiaper,
-                  onTap: () => _openDiaperAction(context),
-                ),
-              ],
+            _ActionsCarousel(
+              onFeed: () => _openFeedAction(context),
+              onBath: () => _openBathAction(context),
+              onVomit: () => _openVomitAction(context),
+              onDiaper: () => _openDiaperAction(context),
+              onHistory: () => _openHistory(context),
+              onStatistics: () => _openStatistics(context),
+              onAskPediatrician: () => _openAskPediatrician(context),
+              onMedicalAgenda: () => _openMedicalAgenda(context),
+              onGrowth: () => _openGrowth(context),
             ),
+            const SizedBox(height: 24),
+            const _LatestEventsOverview(),
             const SizedBox(height: 32),
             _RecentActionsSection(
               datePicker: datePicker,
@@ -260,6 +247,36 @@ class BabyHomeScreen extends StatelessWidget {
     _showResultSnack(context, message);
   }
 
+  void _openHistory(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    _openFeatureComingSoon(context, l10n.babyActionHistory);
+  }
+
+  void _openStatistics(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    _openFeatureComingSoon(context, l10n.babyActionStatistics);
+  }
+
+  void _openAskPediatrician(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    _openFeatureComingSoon(context, l10n.babyActionAskPediatrician);
+  }
+
+  void _openMedicalAgenda(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    _openFeatureComingSoon(context, l10n.babyActionMedicalAgenda);
+  }
+
+  void _openGrowth(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    _openFeatureComingSoon(context, l10n.babyActionGrowth);
+  }
+
+  void _openFeatureComingSoon(BuildContext context, String feature) {
+    final l10n = AppLocalizations.of(context)!;
+    _showSnack(context, l10n.babyHomeFeatureComingSoon(feature));
+  }
+
   void _showResultSnack(BuildContext context, String? message) {
     if (message == null || !context.mounted) {
       return;
@@ -268,6 +285,188 @@ class BabyHomeScreen extends StatelessWidget {
       ..hideCurrentSnackBar()
       ..showSnackBar(SnackBar(content: Text(message)));
   }
+}
+
+class _LatestEventsOverview extends StatelessWidget {
+  const _LatestEventsOverview();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+
+    return Consumer<BabyActionsState>(
+      builder: (context, state, _) {
+        final material = MaterialLocalizations.of(context);
+        final now = DateTime.now();
+
+        final entries = <_HighlightEntry>[
+          _HighlightEntry(
+            icon: Icons.local_drink_outlined,
+            label: l10n.babyHomeHighlightsFeed,
+            action: _findLatestAction(state.recentActions, BabyActionKind.feed),
+          ),
+          _HighlightEntry(
+            icon: Icons.baby_changing_station,
+            label: l10n.babyHomeHighlightsDiaper,
+            action: _findLatestAction(state.recentActions, BabyActionKind.diaper),
+          ),
+          _HighlightEntry(
+            icon: Icons.bathtub_outlined,
+            label: l10n.babyHomeHighlightsBath,
+            action: _findLatestAction(state.recentActions, BabyActionKind.bath),
+          ),
+          _HighlightEntry(
+            icon: Icons.sick_outlined,
+            label: l10n.babyHomeHighlightsVomit,
+            action: _findLatestAction(state.recentActions, BabyActionKind.vomit),
+          ),
+        ];
+
+        final hasData = entries.any((entry) => entry.action != null);
+
+        if (state.isLoading && !hasData) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                l10n.babyHomeHighlightsTitle,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Center(child: CircularProgressIndicator()),
+            ],
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.babyHomeHighlightsTitle,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+              color: theme.colorScheme.surface,
+              elevation: 0,
+              clipBehavior: Clip.antiAlias,
+              child: ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                itemCount: entries.length,
+                itemBuilder: (context, index) {
+                  final entry = entries[index];
+                  return _buildHighlightTile(
+                    entry,
+                    theme,
+                    l10n,
+                    material,
+                    now,
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(height: 1),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildHighlightTile(
+    _HighlightEntry entry,
+    ThemeData theme,
+    AppLocalizations l10n,
+    MaterialLocalizations material,
+    DateTime reference,
+  ) {
+    final action = entry.action;
+    final subtitle = action == null
+        ? l10n.babyHomeHighlightsNoData
+        : l10n.babyHomeHighlightsEntry(
+            material.formatMediumDate(action.occurredAt),
+            material.formatTimeOfDay(
+              TimeOfDay.fromDateTime(action.occurredAt),
+              alwaysUse24HourFormat: true,
+            ),
+            _formatElapsedSince(action.occurredAt, reference),
+          );
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: theme.colorScheme.primary.withOpacity(0.1),
+        foregroundColor: theme.colorScheme.primary,
+        child: Icon(entry.icon),
+      ),
+      title: Text(
+        entry.label,
+        style: theme.textTheme.titleSmall?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      subtitle: Text(subtitle),
+    );
+  }
+}
+
+class _HighlightEntry {
+  const _HighlightEntry({
+    required this.icon,
+    required this.label,
+    this.action,
+  });
+
+  final IconData icon;
+  final String label;
+  final BabyAction? action;
+}
+
+BabyAction? _findLatestAction(
+  Iterable<BabyAction> actions,
+  BabyActionKind kind,
+) {
+  for (final action in actions) {
+    if (action.kind == kind) {
+      return action;
+    }
+  }
+  return null;
+}
+
+String _formatElapsedSince(DateTime occurredAt, DateTime reference) {
+  final difference = reference.difference(occurredAt);
+  if (difference.isNegative) {
+    return '0s';
+  }
+  final days = difference.inDays;
+  final hours = difference.inHours.remainder(24);
+  final minutes = difference.inMinutes.remainder(60);
+  final seconds = difference.inSeconds.remainder(60);
+
+  final parts = <String>[];
+  if (days > 0) {
+    parts.add('${days}d');
+  }
+  if (hours > 0) {
+    parts.add('${hours}h');
+  }
+  if (minutes > 0) {
+    parts.add('${minutes}m');
+  }
+  if (parts.isEmpty) {
+    parts.add('${seconds}s');
+  }
+
+  return parts.join(' ');
 }
 
 class _RecentActionsSection extends StatelessWidget {
@@ -723,6 +922,113 @@ String _diaperTextureLabel(StoolTexture texture, AppLocalizations l10n) {
     case StoolTexture.solid:
       return l10n.diaperTextureSolid;
   }
+}
+
+class _ActionsCarousel extends StatelessWidget {
+  const _ActionsCarousel({
+    required this.onFeed,
+    required this.onBath,
+    required this.onVomit,
+    required this.onDiaper,
+    required this.onHistory,
+    required this.onStatistics,
+    required this.onAskPediatrician,
+    required this.onMedicalAgenda,
+    required this.onGrowth,
+  });
+
+  final VoidCallback onFeed;
+  final VoidCallback onBath;
+  final VoidCallback onVomit;
+  final VoidCallback onDiaper;
+  final VoidCallback onHistory;
+  final VoidCallback onStatistics;
+  final VoidCallback onAskPediatrician;
+  final VoidCallback onMedicalAgenda;
+  final VoidCallback onGrowth;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    final actions = <_CarouselAction>[
+      _CarouselAction(
+        icon: Icons.local_drink_outlined,
+        tooltip: l10n.babyActionFeed,
+        onTap: onFeed,
+      ),
+      _CarouselAction(
+        icon: Icons.bathtub_outlined,
+        tooltip: l10n.babyActionBath,
+        onTap: onBath,
+      ),
+      _CarouselAction(
+        icon: Icons.sick_outlined,
+        tooltip: l10n.babyActionVomited,
+        onTap: onVomit,
+      ),
+      _CarouselAction(
+        icon: Icons.baby_changing_station,
+        tooltip: l10n.babyActionDiaper,
+        onTap: onDiaper,
+      ),
+      _CarouselAction(
+        icon: Icons.history_toggle_off,
+        tooltip: l10n.babyActionHistory,
+        onTap: onHistory,
+      ),
+      _CarouselAction(
+        icon: Icons.bar_chart_outlined,
+        tooltip: l10n.babyActionStatistics,
+        onTap: onStatistics,
+      ),
+      _CarouselAction(
+        icon: Icons.contact_support_outlined,
+        tooltip: l10n.babyActionAskPediatrician,
+        onTap: onAskPediatrician,
+      ),
+      _CarouselAction(
+        icon: Icons.event_note_outlined,
+        tooltip: l10n.babyActionMedicalAgenda,
+        onTap: onMedicalAgenda,
+      ),
+      _CarouselAction(
+        icon: Icons.show_chart_outlined,
+        tooltip: l10n.babyActionGrowth,
+        onTap: onGrowth,
+      ),
+    ];
+
+    return SizedBox(
+      height: 80,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        itemBuilder: (context, index) {
+          final action = actions[index];
+          return _ActionButton(
+            icon: action.icon,
+            tooltip: action.tooltip,
+            onTap: action.onTap,
+          );
+        },
+        separatorBuilder: (_, __) => const SizedBox(width: 12),
+        itemCount: actions.length,
+      ),
+    );
+  }
+}
+
+class _CarouselAction {
+  const _CarouselAction({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
 }
 
 class _ActionButton extends StatelessWidget {


### PR DESCRIPTION
## Summary
- add a horizontal carousel so all baby quick actions sit in a single scrollable row, including the five new shortcuts
- surface a highlights card above the recent actions list that shows the last feed, diaper, bath, and vomit times with relative elapsed labels
- localize the new carousel labels, highlight strings, and placeholder messaging in English and Spanish

## Testing
- not run (Flutter/Dart tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68e2c23101c08332875a207a4fd6ff16