### PR TITLE
Fix locale restoration to supported base locales

### DIFF
--- a/lib/presentation/app_settings.dart
+++ b/lib/presentation/app_settings.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/theme/app_color_palettes.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -171,7 +172,8 @@ class SharedPreferencesAppSettingsStore implements AppSettingsStore {
       if (localeTag == null || localeTag.isEmpty) {
         return null;
       }
-      return _parseLocale(localeTag);
+      final parsed = _parseLocale(localeTag);
+      return _matchSupportedLocale(parsed);
     } catch (_) {
       return null;
     }
@@ -256,6 +258,27 @@ class SharedPreferencesAppSettingsStore implements AppSettingsStore {
       scriptCode: scriptCode,
       countryCode: countryCode,
     );
+  }
+
+  Locale? _matchSupportedLocale(Locale? locale) {
+    if (locale == null) {
+      return null;
+    }
+
+    for (final supported in AppLocalizations.supportedLocales) {
+      if (supported == locale) {
+        return supported;
+      }
+    }
+
+    final targetLanguage = locale.languageCode.toLowerCase();
+    for (final supported in AppLocalizations.supportedLocales) {
+      if (supported.languageCode.toLowerCase() == targetLanguage) {
+        return supported;
+      }
+    }
+
+    return null;
   }
 
   String _toTag(Locale locale) {

--- a/test/presentation/app_settings_store_test.dart
+++ b/test/presentation/app_settings_store_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pequelog/presentation/app_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SharedPreferencesAppSettingsStore.loadLocale', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues(<String, Object?>{});
+    });
+
+    test('returns supported locale when stored tag includes region', () async {
+      SharedPreferences.setMockInitialValues(<String, Object?>{
+        'presentation.locale': 'es-ES',
+      });
+
+      const store = SharedPreferencesAppSettingsStore();
+
+      final locale = await store.loadLocale();
+
+      expect(locale, const Locale('es'));
+    });
+
+    test('returns null when stored locale is unsupported', () async {
+      SharedPreferences.setMockInitialValues(<String, Object?>{
+        'presentation.locale': 'fr',
+      });
+
+      const store = SharedPreferencesAppSettingsStore();
+
+      final locale = await store.loadLocale();
+
+      expect(locale, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- normalize stored locales to the supported base locales when restoring settings
- add coverage to ensure unsupported locales fall back or return null

## Testing
- Not Run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e2c77113d08332a201a955f651758c