### PR TITLE
feat: unify baby action day selectors and add feed timeline

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -98,6 +98,11 @@
   "actionNotesHint": "Add details or observations",
   "actionDatePickerHelp": "Pick the day of the activity",
   "actionTimePickerHelp": "Pick the time of the activity",
+  "actionDayPrevious": "Previous day",
+  "actionDayNext": "Next day",
+  "actionDayPickerTooltip": "Pick day",
+  "actionDayToday": "TODAY",
+  "actionDayYesterday": "YESTERDAY",
   "feedDaySelectorLabel": "Feeding day",
   "feedDayPrevious": "Previous day",
   "feedDayNext": "Next day",
@@ -122,6 +127,27 @@
   "feedActionUpdateSuccess": "Feed updated",
   "feedActionError": "We couldn't save the feed. Try again.",
   "feedActionEditTitle": "Edit feed",
+  "feedTimelineTitle": "Feeds for the day",
+  "feedTimelineEmpty": "No feeds recorded for this day yet.",
+  "feedTimelineGapLabel": "{duration} between feeds",
+  "@feedTimelineGapLabel": {
+    "placeholders": {
+      "duration": {}
+    }
+  },
+  "feedTimelineGapShort": "less than a minute",
+  "feedTimelineAmountLabel": "Amount: {amount} ml",
+  "@feedTimelineAmountLabel": {
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "feedTimelineDurationLabel": "Duration: {duration}",
+  "@feedTimelineDurationLabel": {
+    "placeholders": {
+      "duration": {}
+    }
+  },
   "bathDurationLabel": "Bath duration",
   "bathDurationHint": "Minutes",
   "bathDurationHelper": "Leave empty if you don't want to track it",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -98,6 +98,11 @@
   "actionNotesHint": "Agrega detalles u observaciones",
   "actionDatePickerHelp": "Elige el día de la actividad",
   "actionTimePickerHelp": "Elige la hora de la actividad",
+  "actionDayPrevious": "Día anterior",
+  "actionDayNext": "Día siguiente",
+  "actionDayPickerTooltip": "Elegir día",
+  "actionDayToday": "HOY",
+  "actionDayYesterday": "AYER",
   "feedDaySelectorLabel": "Día de la toma",
   "feedDayPrevious": "Día anterior",
   "feedDayNext": "Día siguiente",
@@ -122,6 +127,27 @@
   "feedActionUpdateSuccess": "Toma actualizada",
   "feedActionError": "No pudimos guardar la toma. Inténtalo de nuevo.",
   "feedActionEditTitle": "Editar toma",
+  "feedTimelineTitle": "Tomas del día",
+  "feedTimelineEmpty": "Aún no registraste tomas en este día.",
+  "feedTimelineGapLabel": "{duration} entre tomas",
+  "@feedTimelineGapLabel": {
+    "placeholders": {
+      "duration": {}
+    }
+  },
+  "feedTimelineGapShort": "menos de un minuto",
+  "feedTimelineAmountLabel": "Cantidad: {amount} ml",
+  "@feedTimelineAmountLabel": {
+    "placeholders": {
+      "amount": {}
+    }
+  },
+  "feedTimelineDurationLabel": "Duración: {duration}",
+  "@feedTimelineDurationLabel": {
+    "placeholders": {
+      "duration": {}
+    }
+  },
   "bathDurationLabel": "Duración del baño",
   "bathDurationHint": "Minutos",
   "bathDurationHelper": "Déjalo vacío si no quieres registrarlo",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -518,6 +518,36 @@ abstract class AppLocalizations {
   /// **'Elige la hora de la actividad'**
   String get actionTimePickerHelp;
 
+  /// No description provided for @actionDayPrevious.
+  ///
+  /// In es, this message translates to:
+  /// **'Día anterior'**
+  String get actionDayPrevious;
+
+  /// No description provided for @actionDayNext.
+  ///
+  /// In es, this message translates to:
+  /// **'Día siguiente'**
+  String get actionDayNext;
+
+  /// No description provided for @actionDayPickerTooltip.
+  ///
+  /// In es, this message translates to:
+  /// **'Elegir día'**
+  String get actionDayPickerTooltip;
+
+  /// No description provided for @actionDayToday.
+  ///
+  /// In es, this message translates to:
+  /// **'HOY'**
+  String get actionDayToday;
+
+  /// No description provided for @actionDayYesterday.
+  ///
+  /// In es, this message translates to:
+  /// **'AYER'**
+  String get actionDayYesterday;
+
   /// No description provided for @feedDaySelectorLabel.
   ///
   /// In es, this message translates to:
@@ -661,6 +691,42 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'Editar toma'**
   String get feedActionEditTitle;
+
+  /// No description provided for @feedTimelineTitle.
+  ///
+  /// In es, this message translates to:
+  /// **'Tomas del día'**
+  String get feedTimelineTitle;
+
+  /// No description provided for @feedTimelineEmpty.
+  ///
+  /// In es, this message translates to:
+  /// **'Aún no registraste tomas en este día.'**
+  String get feedTimelineEmpty;
+
+  /// No description provided for @feedTimelineGapLabel.
+  ///
+  /// In es, this message translates to:
+  /// **'{duration} entre tomas'**
+  String feedTimelineGapLabel(Object duration);
+
+  /// No description provided for @feedTimelineGapShort.
+  ///
+  /// In es, this message translates to:
+  /// **'menos de un minuto'**
+  String get feedTimelineGapShort;
+
+  /// No description provided for @feedTimelineAmountLabel.
+  ///
+  /// In es, this message translates to:
+  /// **'Cantidad: {amount} ml'**
+  String feedTimelineAmountLabel(Object amount);
+
+  /// No description provided for @feedTimelineDurationLabel.
+  ///
+  /// In es, this message translates to:
+  /// **'Duración: {duration}'**
+  String feedTimelineDurationLabel(Object duration);
 
   /// No description provided for @bathDurationLabel.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -232,6 +232,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get actionTimePickerHelp => 'Pick the time of the activity';
 
   @override
+  String get actionDayPrevious => 'Previous day';
+
+  @override
+  String get actionDayNext => 'Next day';
+
+  @override
+  String get actionDayPickerTooltip => 'Pick day';
+
+  @override
+  String get actionDayToday => 'TODAY';
+
+  @override
+  String get actionDayYesterday => 'YESTERDAY';
+
+  @override
   String get feedDaySelectorLabel => 'Feeding day';
 
   @override
@@ -306,6 +321,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get feedActionEditTitle => 'Edit feed';
+
+  @override
+  String get feedTimelineTitle => 'Feeds for the day';
+
+  @override
+  String get feedTimelineEmpty => 'No feeds recorded for this day yet.';
+
+  @override
+  String feedTimelineGapLabel(Object duration) {
+    return '$duration between feeds';
+  }
+
+  @override
+  String get feedTimelineGapShort => 'less than a minute';
+
+  @override
+  String feedTimelineAmountLabel(Object amount) {
+    return 'Amount: $amount ml';
+  }
+
+  @override
+  String feedTimelineDurationLabel(Object duration) {
+    return 'Duration: $duration';
+  }
 
   @override
   String get bathDurationLabel => 'Bath duration';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -232,6 +232,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get actionTimePickerHelp => 'Elige la hora de la actividad';
 
   @override
+  String get actionDayPrevious => 'Día anterior';
+
+  @override
+  String get actionDayNext => 'Día siguiente';
+
+  @override
+  String get actionDayPickerTooltip => 'Elegir día';
+
+  @override
+  String get actionDayToday => 'HOY';
+
+  @override
+  String get actionDayYesterday => 'AYER';
+
+  @override
   String get feedDaySelectorLabel => 'Día de la toma';
 
   @override
@@ -307,6 +322,30 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get feedActionEditTitle => 'Editar toma';
+
+  @override
+  String get feedTimelineTitle => 'Tomas del día';
+
+  @override
+  String get feedTimelineEmpty => 'Aún no registraste tomas en este día.';
+
+  @override
+  String feedTimelineGapLabel(Object duration) {
+    return '$duration entre tomas';
+  }
+
+  @override
+  String get feedTimelineGapShort => 'menos de un minuto';
+
+  @override
+  String feedTimelineAmountLabel(Object amount) {
+    return 'Cantidad: $amount ml';
+  }
+
+  @override
+  String feedTimelineDurationLabel(Object duration) {
+    return 'Duración: $duration';
+  }
 
   @override
   String get bathDurationLabel => 'Duración del baño';

--- a/lib/presentation/features/babies/actions/bath_action_screen.dart
+++ b/lib/presentation/features/babies/actions/bath_action_screen.dart
@@ -3,6 +3,7 @@ import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/baby_actions/action_pickers.dart';
 import 'package:pequelog/presentation/features/baby_actions/baby_actions_state.dart';
 import 'package:pequelog/presentation/features/babies/new_baby_screen.dart';
+import 'package:pequelog/presentation/widgets/action_day_selector.dart';
 import 'package:provider/provider.dart';
 
 /// Screen that captures bath details for the daily log.
@@ -23,7 +24,6 @@ class BathActionScreen extends StatefulWidget {
 
 class _BathActionScreenState extends State<BathActionScreen> {
   final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _dateController;
   late final TextEditingController _timeController;
   late final TextEditingController _durationController;
   late final TextEditingController _notesController;
@@ -39,7 +39,6 @@ class _BathActionScreenState extends State<BathActionScreen> {
     final now = DateTime.now();
     _selectedDate = DateTime(now.year, now.month, now.day);
     _selectedTime = TimeOfDay.fromDateTime(now);
-    _dateController = TextEditingController();
     _timeController = TextEditingController();
     _durationController = TextEditingController();
     _notesController = TextEditingController();
@@ -52,7 +51,6 @@ class _BathActionScreenState extends State<BathActionScreen> {
       return;
     }
     final material = MaterialLocalizations.of(context);
-    _dateController.text = material.formatMediumDate(_selectedDate);
     _timeController.text = material.formatTimeOfDay(
       _selectedTime,
       alwaysUse24HourFormat: true,
@@ -62,7 +60,6 @@ class _BathActionScreenState extends State<BathActionScreen> {
 
   @override
   void dispose() {
-    _dateController.dispose();
     _timeController.dispose();
     _durationController.dispose();
     _notesController.dispose();
@@ -78,8 +75,6 @@ class _BathActionScreenState extends State<BathActionScreen> {
     }
     setState(() {
       _selectedDate = DateTime(picked.year, picked.month, picked.day);
-      final material = MaterialLocalizations.of(context);
-      _dateController.text = material.formatMediumDate(_selectedDate);
     });
   }
 
@@ -169,15 +164,15 @@ class _BathActionScreenState extends State<BathActionScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                TextFormField(
-                  key: const Key('bath_date'),
-                  controller: _dateController,
-                  readOnly: true,
-                  decoration: InputDecoration(
-                    labelText: l10n.actionDateLabel,
-                    hintText: l10n.actionDateHint,
-                  ),
-                  onTap: _pickDate,
+                ActionDaySelector(
+                  label: l10n.actionDateLabel,
+                  selectedDate: _selectedDate,
+                  onPickDay: _pickDate,
+                  onPreviousDay: () => _changeDay(-1),
+                  onNextDay: () => _changeDay(1),
+                  previousTooltip: l10n.actionDayPrevious,
+                  nextTooltip: l10n.actionDayNext,
+                  pickerTooltip: l10n.actionDayPickerTooltip,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
@@ -233,5 +228,11 @@ class _BathActionScreenState extends State<BathActionScreen> {
         ),
       ),
     );
+  }
+
+  void _changeDay(int delta) {
+    setState(() {
+      _selectedDate = _selectedDate.add(Duration(days: delta));
+    });
   }
 }

--- a/lib/presentation/features/babies/actions/diaper_action_screen.dart
+++ b/lib/presentation/features/babies/actions/diaper_action_screen.dart
@@ -4,6 +4,7 @@ import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/baby_actions/action_pickers.dart';
 import 'package:pequelog/presentation/features/baby_actions/baby_actions_state.dart';
 import 'package:pequelog/presentation/features/babies/new_baby_screen.dart';
+import 'package:pequelog/presentation/widgets/action_day_selector.dart';
 import 'package:provider/provider.dart';
 
 /// Form that registers diaper changes with stool details.
@@ -24,7 +25,6 @@ class DiaperActionScreen extends StatefulWidget {
 
 class _DiaperActionScreenState extends State<DiaperActionScreen> {
   final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _dateController;
   late final TextEditingController _timeController;
   late final TextEditingController _notesController;
 
@@ -41,7 +41,6 @@ class _DiaperActionScreenState extends State<DiaperActionScreen> {
     final now = DateTime.now();
     _selectedDate = DateTime(now.year, now.month, now.day);
     _selectedTime = TimeOfDay.fromDateTime(now);
-    _dateController = TextEditingController();
     _timeController = TextEditingController();
     _notesController = TextEditingController();
   }
@@ -53,7 +52,6 @@ class _DiaperActionScreenState extends State<DiaperActionScreen> {
       return;
     }
     final material = MaterialLocalizations.of(context);
-    _dateController.text = material.formatMediumDate(_selectedDate);
     _timeController.text = material.formatTimeOfDay(
       _selectedTime,
       alwaysUse24HourFormat: true,
@@ -63,7 +61,6 @@ class _DiaperActionScreenState extends State<DiaperActionScreen> {
 
   @override
   void dispose() {
-    _dateController.dispose();
     _timeController.dispose();
     _notesController.dispose();
     super.dispose();
@@ -78,8 +75,6 @@ class _DiaperActionScreenState extends State<DiaperActionScreen> {
     }
     setState(() {
       _selectedDate = DateTime(picked.year, picked.month, picked.day);
-      final material = MaterialLocalizations.of(context);
-      _dateController.text = material.formatMediumDate(_selectedDate);
     });
   }
 
@@ -163,15 +158,15 @@ class _DiaperActionScreenState extends State<DiaperActionScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                TextFormField(
-                  key: const Key('diaper_date'),
-                  controller: _dateController,
-                  readOnly: true,
-                  decoration: InputDecoration(
-                    labelText: l10n.actionDateLabel,
-                    hintText: l10n.actionDateHint,
-                  ),
-                  onTap: _pickDate,
+                ActionDaySelector(
+                  label: l10n.actionDateLabel,
+                  selectedDate: _selectedDate,
+                  onPickDay: _pickDate,
+                  onPreviousDay: () => _changeDay(-1),
+                  onNextDay: () => _changeDay(1),
+                  previousTooltip: l10n.actionDayPrevious,
+                  nextTooltip: l10n.actionDayNext,
+                  pickerTooltip: l10n.actionDayPickerTooltip,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
@@ -248,6 +243,12 @@ class _DiaperActionScreenState extends State<DiaperActionScreen> {
         ),
       ),
     );
+  }
+
+  void _changeDay(int delta) {
+    setState(() {
+      _selectedDate = _selectedDate.add(Duration(days: delta));
+    });
   }
 
   String _textureLabel(StoolTexture texture, AppLocalizations l10n) {

--- a/lib/presentation/features/babies/actions/feed_action_screen.dart
+++ b/lib/presentation/features/babies/actions/feed_action_screen.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:pequelog/domain/baby_actions/entities/baby_action.dart';
+import 'package:pequelog/domain/baby_actions/entities/baby_action_kind.dart';
 import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/baby_actions/action_pickers.dart';
 import 'package:pequelog/presentation/features/baby_actions/baby_actions_state.dart';
 import 'package:pequelog/presentation/features/baby_actions/feed_timer_state.dart';
 import 'package:pequelog/presentation/features/babies/new_baby_screen.dart';
+import 'package:pequelog/presentation/widgets/action_day_selector.dart';
 import 'package:provider/provider.dart';
 
 /// Form that lets caregivers log feeding sessions quickly.
@@ -208,6 +210,7 @@ class _FeedActionScreenState extends State<FeedActionScreen> {
   @override
   Widget build(BuildContext context) {
     final timerState = context.watch<FeedTimerState>();
+    final actionsState = context.watch<BabyActionsState>();
     final timerStart = timerState.startedAt;
     if (timerStart != null) {
       final lastSynced = _lastSyncedTimerStart;
@@ -239,7 +242,6 @@ class _FeedActionScreenState extends State<FeedActionScreen> {
     final l10n = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final material = MaterialLocalizations.of(context);
-    final dayLabel = material.formatMediumDate(_selectedDate);
     final title =
         widget.initialAction == null ? l10n.babyActionFeed : l10n.feedActionEditTitle;
 
@@ -253,60 +255,17 @@ class _FeedActionScreenState extends State<FeedActionScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  l10n.feedDaySelectorLabel,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                const SizedBox(height: 12),
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(
-                      color: theme.colorScheme.outlineVariant,
-                    ),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    child: Row(
-                      children: [
-                        IconButton(
-                          key: const Key('feed_day_previous'),
-                          tooltip: l10n.feedDayPrevious,
-                          onPressed: () => _changeDay(-1),
-                          icon: const Icon(Icons.chevron_left),
-                        ),
-                        Expanded(
-                          child: Tooltip(
-                            message: l10n.feedDayPickerTooltip,
-                            child: Material(
-                              color: Colors.transparent,
-                              child: InkWell(
-                                onTap: _pickDate,
-                                borderRadius: BorderRadius.circular(12),
-                                child: Padding(
-                                  padding:
-                                      const EdgeInsets.symmetric(vertical: 6),
-                                  child: Text(
-                                    dayLabel,
-                                    textAlign: TextAlign.center,
-                                    style: theme.textTheme.titleMedium,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        IconButton(
-                          key: const Key('feed_day_next'),
-                          tooltip: l10n.feedDayNext,
-                          onPressed: () => _changeDay(1),
-                          icon: const Icon(Icons.chevron_right),
-                        ),
-                      ],
-                    ),
-                  ),
+                ActionDaySelector(
+                  label: l10n.feedDaySelectorLabel,
+                  selectedDate: _selectedDate,
+                  onPickDay: _pickDate,
+                  onPreviousDay: () => _changeDay(-1),
+                  onNextDay: () => _changeDay(1),
+                  previousTooltip: l10n.feedDayPrevious,
+                  nextTooltip: l10n.feedDayNext,
+                  pickerTooltip: l10n.feedDayPickerTooltip,
+                  previousButtonKey: const Key('feed_day_previous'),
+                  nextButtonKey: const Key('feed_day_next'),
                 ),
                 const SizedBox(height: 16),
                 Row(
@@ -408,6 +367,12 @@ class _FeedActionScreenState extends State<FeedActionScreen> {
                           ),
                   ),
                 ),
+                _buildFeedTimelineSection(
+                  l10n,
+                  theme,
+                  material,
+                  actionsState,
+                ),
               ],
             ),
           ),
@@ -508,6 +473,135 @@ class _FeedActionScreenState extends State<FeedActionScreen> {
     );
   }
 
+  Widget _buildFeedTimelineSection(
+    AppLocalizations l10n,
+    ThemeData theme,
+    MaterialLocalizations material,
+    BabyActionsState actionsState,
+  ) {
+    final feeds = actionsState.recentActions
+        .where(
+          (action) =>
+              action.kind == BabyActionKind.feed &&
+              _isSameDay(action.occurredAt, _selectedDate),
+        )
+        .toList()
+      ..sort((a, b) => a.occurredAt.compareTo(b.occurredAt));
+
+    if (feeds.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.only(top: 32),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.feedTimelineTitle,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.feedTimelineEmpty,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final entries = <Widget>[];
+    for (var index = 0; index < feeds.length; index++) {
+      final action = feeds[index];
+      final timeLabel = material.formatTimeOfDay(
+        TimeOfDay.fromDateTime(action.occurredAt),
+        alwaysUse24HourFormat: true,
+      );
+      final amount = (action.details['amountMl'] as num?)?.toDouble();
+      final amountLabel =
+          amount != null ? l10n.feedTimelineAmountLabel(_formatAmount(amount)) : null;
+      final durationSeconds = action.details['durationSeconds'] as int?;
+      final durationLabel = durationSeconds != null && durationSeconds > 0
+          ? l10n.feedTimelineDurationLabel(
+              _formatDuration(Duration(seconds: durationSeconds)),
+            )
+          : null;
+      final notes = action.notes?.trim();
+      final showConnector = index < feeds.length - 1;
+      final gapLabel = showConnector
+          ? _buildGapLabel(
+              feeds[index + 1].occurredAt.difference(action.occurredAt),
+              l10n,
+            )
+          : null;
+
+      entries.add(
+        _FeedTimelineEntry(
+          timeLabel: timeLabel,
+          amountLabel: amountLabel,
+          durationLabel: durationLabel,
+          notes: notes?.isEmpty ?? true ? null : notes,
+          showConnector: showConnector,
+          connectorLabel: gapLabel,
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.feedTimelineTitle,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...entries,
+        ],
+      ),
+    );
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  String _formatAmount(double amount) {
+    final text = amount.toStringAsFixed(2);
+    if (text.endsWith('.00')) {
+      return text.substring(0, text.length - 3);
+    }
+    if (text.endsWith('0')) {
+      return text.substring(0, text.length - 1);
+    }
+    return text;
+  }
+
+  String? _buildGapLabel(Duration gap, AppLocalizations l10n) {
+    if (gap.isNegative) {
+      return null;
+    }
+    if (gap.inSeconds < 60) {
+      return l10n.feedTimelineGapLabel(l10n.feedTimelineGapShort);
+    }
+    final hours = gap.inHours;
+    final minutes = gap.inMinutes.remainder(60);
+    final parts = <String>[];
+    if (hours > 0) {
+      parts.add('$hours h');
+    }
+    if (minutes > 0) {
+      parts.add('$minutes min');
+    }
+    final label = parts.isEmpty ? l10n.feedTimelineGapShort : parts.join(' ');
+    return l10n.feedTimelineGapLabel(label);
+  }
+
   void _hydrateInitialTimeLabel() {
     if (_timeController.text.isNotEmpty) {
       return;
@@ -598,5 +692,126 @@ class _FeedActionScreenState extends State<FeedActionScreen> {
       return '$hoursLabel:$minutes:$seconds';
     }
     return '$minutes:$seconds';
+  }
+}
+
+class _FeedTimelineEntry extends StatelessWidget {
+  const _FeedTimelineEntry({
+    required this.timeLabel,
+    this.amountLabel,
+    this.durationLabel,
+    this.notes,
+    required this.showConnector,
+    this.connectorLabel,
+  });
+
+  final String timeLabel;
+  final String? amountLabel;
+  final String? durationLabel;
+  final String? notes;
+  final bool showConnector;
+  final String? connectorLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final outline = theme.colorScheme.outlineVariant;
+    final notesLabel = AppLocalizations.of(context)!.actionNotesLabel;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 32,
+              child: Column(
+                children: [
+                  Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primary,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    timeLabel,
+                    style: textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (amountLabel != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      amountLabel!,
+                      style: textTheme.bodyMedium,
+                    ),
+                  ],
+                  if (durationLabel != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      durationLabel!,
+                      style: textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                  if (notes != null && notes!.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      '$notesLabel: ${notes!}',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.outline,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+        if (showConnector) ...[
+          const SizedBox(height: 8),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: 32,
+                child: Align(
+                  alignment: Alignment.center,
+                  child: Container(
+                    width: 2,
+                    height: 36,
+                    color: outline,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  connectorLabel ?? '',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.outline,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+        ] else
+          const SizedBox(height: 16),
+      ],
+    );
   }
 }

--- a/lib/presentation/features/babies/actions/vomit_action_screen.dart
+++ b/lib/presentation/features/babies/actions/vomit_action_screen.dart
@@ -4,6 +4,7 @@ import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/baby_actions/action_pickers.dart';
 import 'package:pequelog/presentation/features/baby_actions/baby_actions_state.dart';
 import 'package:pequelog/presentation/features/babies/new_baby_screen.dart';
+import 'package:pequelog/presentation/widgets/action_day_selector.dart';
 import 'package:provider/provider.dart';
 
 /// Form used to capture vomit events and their severity.
@@ -24,7 +25,6 @@ class VomitActionScreen extends StatefulWidget {
 
 class _VomitActionScreenState extends State<VomitActionScreen> {
   final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _dateController;
   late final TextEditingController _timeController;
   late final TextEditingController _notesController;
 
@@ -40,7 +40,6 @@ class _VomitActionScreenState extends State<VomitActionScreen> {
     final now = DateTime.now();
     _selectedDate = DateTime(now.year, now.month, now.day);
     _selectedTime = TimeOfDay.fromDateTime(now);
-    _dateController = TextEditingController();
     _timeController = TextEditingController();
     _notesController = TextEditingController();
   }
@@ -52,7 +51,6 @@ class _VomitActionScreenState extends State<VomitActionScreen> {
       return;
     }
     final material = MaterialLocalizations.of(context);
-    _dateController.text = material.formatMediumDate(_selectedDate);
     _timeController.text = material.formatTimeOfDay(
       _selectedTime,
       alwaysUse24HourFormat: true,
@@ -62,7 +60,6 @@ class _VomitActionScreenState extends State<VomitActionScreen> {
 
   @override
   void dispose() {
-    _dateController.dispose();
     _timeController.dispose();
     _notesController.dispose();
     super.dispose();
@@ -77,8 +74,6 @@ class _VomitActionScreenState extends State<VomitActionScreen> {
     }
     setState(() {
       _selectedDate = DateTime(picked.year, picked.month, picked.day);
-      final material = MaterialLocalizations.of(context);
-      _dateController.text = material.formatMediumDate(_selectedDate);
     });
   }
 
@@ -162,15 +157,15 @@ class _VomitActionScreenState extends State<VomitActionScreen> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                TextFormField(
-                  key: const Key('vomit_date'),
-                  controller: _dateController,
-                  readOnly: true,
-                  decoration: InputDecoration(
-                    labelText: l10n.actionDateLabel,
-                    hintText: l10n.actionDateHint,
-                  ),
-                  onTap: _pickDate,
+                ActionDaySelector(
+                  label: l10n.actionDateLabel,
+                  selectedDate: _selectedDate,
+                  onPickDay: _pickDate,
+                  onPreviousDay: () => _changeDay(-1),
+                  onNextDay: () => _changeDay(1),
+                  previousTooltip: l10n.actionDayPrevious,
+                  nextTooltip: l10n.actionDayNext,
+                  pickerTooltip: l10n.actionDayPickerTooltip,
                 ),
                 const SizedBox(height: 16),
                 TextFormField(
@@ -240,6 +235,12 @@ class _VomitActionScreenState extends State<VomitActionScreen> {
         ),
       ),
     );
+  }
+
+  void _changeDay(int delta) {
+    setState(() {
+      _selectedDate = _selectedDate.add(Duration(days: delta));
+    });
   }
 
   String _severityLabel(VomitSeverity severity, AppLocalizations l10n) {

--- a/lib/presentation/widgets/action_day_selector.dart
+++ b/lib/presentation/widgets/action_day_selector.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:pequelog/l10n/app_localizations.dart';
+
+/// Shared selector that displays a day carousel with previous/next controls.
+class ActionDaySelector extends StatelessWidget {
+  /// Creates a reusable day selector carousel.
+  const ActionDaySelector({
+    super.key,
+    required this.label,
+    required this.selectedDate,
+    required this.onPickDay,
+    required this.onPreviousDay,
+    required this.onNextDay,
+    required this.previousTooltip,
+    required this.nextTooltip,
+    required this.pickerTooltip,
+    this.previousButtonKey,
+    this.nextButtonKey,
+  });
+
+  /// Title displayed above the selector.
+  final String label;
+
+  /// Day currently highlighted by the carousel.
+  final DateTime selectedDate;
+
+  /// Callback triggered when the central day chip is tapped.
+  final VoidCallback onPickDay;
+
+  /// Callback for the previous day button.
+  final VoidCallback onPreviousDay;
+
+  /// Callback for the next day button.
+  final VoidCallback onNextDay;
+
+  /// Tooltip shown when hovering the previous button.
+  final String previousTooltip;
+
+  /// Tooltip shown when hovering the next button.
+  final String nextTooltip;
+
+  /// Tooltip displayed when tapping the central chip.
+  final String pickerTooltip;
+
+  /// Optional key for the previous button (useful in tests).
+  final Key? previousButtonKey;
+
+  /// Optional key for the next button (useful in tests).
+  final Key? nextButtonKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final material = MaterialLocalizations.of(context);
+
+    final dayLabel = _formatDayLabel(
+      selectedDate,
+      material,
+      l10n,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 12),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: theme.colorScheme.outlineVariant,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Row(
+              children: [
+                IconButton(
+                  key: previousButtonKey,
+                  tooltip: previousTooltip,
+                  onPressed: onPreviousDay,
+                  icon: const Icon(Icons.chevron_left),
+                ),
+                Expanded(
+                  child: Tooltip(
+                    message: pickerTooltip,
+                    child: Material(
+                      color: Colors.transparent,
+                      child: InkWell(
+                        onTap: onPickDay,
+                        borderRadius: BorderRadius.circular(12),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 6),
+                          child: Text(
+                            dayLabel,
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.titleMedium,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  key: nextButtonKey,
+                  tooltip: nextTooltip,
+                  onPressed: onNextDay,
+                  icon: const Icon(Icons.chevron_right),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  static String _formatDayLabel(
+    DateTime selectedDate,
+    MaterialLocalizations material,
+    AppLocalizations l10n,
+  ) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final normalized = DateTime(
+      selectedDate.year,
+      selectedDate.month,
+      selectedDate.day,
+    );
+
+    final difference = normalized.difference(today).inDays;
+    if (difference == 0) {
+      return l10n.actionDayToday;
+    }
+    if (difference == -1) {
+      return l10n.actionDayYesterday;
+    }
+    return material.formatMediumDate(selectedDate);
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable ActionDaySelector widget that renders the carousel day picker with HOY/AYER labels
- update diaper, bath and vomit action forms to use the carousel selector and rely on the new relative day copy
- extend the feed action screen with a daily feed timeline and supporting localization strings

## Testing
- flutter test *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e36563f90483328930a4ad200ec3a5