### PR TITLE
Add legacy CSV import support in settings

### DIFF
--- a/lib/data/baby_actions/legacy_action_csv_parser.dart
+++ b/lib/data/baby_actions/legacy_action_csv_parser.dart
@@ -1,0 +1,157 @@
+import 'dart:convert';
+
+/// Parsed information coming from the legacy CSV export.
+class LegacyActionCsvRecord {
+  /// Builds a row representation.
+  const LegacyActionCsvRecord({
+    required this.occurredAt,
+    this.feedAmountMl,
+    this.didPoop = false,
+    this.didVomit = false,
+    this.didBath = false,
+  });
+
+  /// Moment when the legacy record took place.
+  final DateTime occurredAt;
+
+  /// Optional amount of milk consumed during the feed in millilitres.
+  final double? feedAmountMl;
+
+  /// Whether the record included a stool event.
+  final bool didPoop;
+
+  /// Whether the record included vomit.
+  final bool didVomit;
+
+  /// Whether the record included a bath.
+  final bool didBath;
+}
+
+/// Utility capable of parsing CSV files exported by the legacy application.
+class LegacyActionCsvParser {
+  /// Parses the provided [contents] and returns structured records.
+  List<LegacyActionCsvRecord> parse(String contents) {
+    if (contents.trim().isEmpty) {
+      return const <LegacyActionCsvRecord>[];
+    }
+
+    final sanitized = contents
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\r', '\n');
+    final rawLines = sanitized.split('\n');
+    if (rawLines.length <= 1) {
+      return const <LegacyActionCsvRecord>[];
+    }
+
+    final result = <LegacyActionCsvRecord>[];
+    var isFirstLine = true;
+    for (final originalLine in rawLines) {
+      if (originalLine.trim().isEmpty) {
+        continue;
+      }
+      if (isFirstLine) {
+        isFirstLine = false;
+        continue; // Skip header row.
+      }
+
+      final line = originalLine.replaceAll('\ufeff', '');
+      final columns = _splitCsvLine(line);
+      if (columns.length < 2) {
+        continue;
+      }
+
+      final dateRaw = columns[0].trim();
+      final timeRaw = columns.length > 1 ? columns[1].trim() : '';
+      if (dateRaw.isEmpty || timeRaw.isEmpty) {
+        continue;
+      }
+
+      DateTime occurredAt;
+      try {
+        occurredAt = DateTime.parse('$dateRaw $timeRaw');
+      } catch (_) {
+        continue;
+      }
+
+      double? feedAmount;
+      if (columns.length > 2) {
+        final feedRaw = columns[2].trim();
+        if (feedRaw.isNotEmpty) {
+          final normalized = feedRaw.replaceAll(',', '.');
+          feedAmount = double.tryParse(normalized);
+        }
+      }
+
+      final didPoop = columns.length > 3 && _parseFlag(columns[3]);
+      final didVomit = columns.length > 4 && _parseFlag(columns[4]);
+      final didBath = columns.length > 5 && _parseFlag(columns[5]);
+
+      if (feedAmount == null && !didPoop && !didVomit && !didBath) {
+        continue;
+      }
+
+      result.add(
+        LegacyActionCsvRecord(
+          occurredAt: occurredAt,
+          feedAmountMl: feedAmount,
+          didPoop: didPoop,
+          didVomit: didVomit,
+          didBath: didBath,
+        ),
+      );
+    }
+
+    return result;
+  }
+
+  List<String> _splitCsvLine(String line) {
+    final values = <String>[];
+    final buffer = StringBuffer();
+    var inQuotes = false;
+
+    for (var i = 0; i < line.length; i++) {
+      final char = line[i];
+      if (char == '"') {
+        final isEscapedQuote =
+            inQuotes && i + 1 < line.length && line[i + 1] == '"';
+        if (isEscapedQuote) {
+          buffer.write('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+        continue;
+      }
+
+      if (char == ',' && !inQuotes) {
+        values.add(buffer.toString());
+        buffer.clear();
+        continue;
+      }
+
+      buffer.write(char);
+    }
+
+    values.add(buffer.toString());
+    return values;
+  }
+
+  bool _parseFlag(String input) {
+    if (input.trim().isEmpty) {
+      return false;
+    }
+
+    var normalized = input.trim().toLowerCase();
+    normalized = latin1.decode(latin1.encode(normalized));
+    normalized = normalized
+        .replaceAll(RegExp('[áàäâã]'), 'a')
+        .replaceAll(RegExp('[éèëê]'), 'e')
+        .replaceAll(RegExp('[íìïî]'), 'i')
+        .replaceAll(RegExp('[óòöôõ]'), 'o')
+        .replaceAll(RegExp('[úùüû]'), 'u')
+        .replaceAll('ñ', 'n');
+    normalized = normalized.replaceAll('sí', 'si').replaceAll('sÃ­', 'si');
+
+    return <String>{'si', 's', 'y', 'yes', 'true', '1'}.contains(normalized);
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -208,6 +208,19 @@
   "configurationPaletteLabel": "Color palette",
   "configurationPaletteHint": "Pick the pastel tones you enjoy the most",
   "configurationChangeConfirmation": "Updated",
+  "configurationImportLegacyButton": "Import legacy CSV",
+  "configurationImportLegacyLoading": "Importing records...",
+  "configurationImportNoBaby": "Select a baby before importing.",
+  "configurationImportEmpty": "We couldn't find compatible records in the file.",
+  "configurationImportSuccess": "{count, plural, =0{No records were imported.} =1{1 record imported.} other{{count} records imported.}}",
+  "@configurationImportSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "configurationImportFailure": "We couldn't import the file. Check the format and try again.",
   "configurationPaletteDawnBlush": "Blush sunrise",
   "configurationPaletteMintWhisper": "Mint whisper",
   "configurationPaletteSkyBreeze": "Sky breeze",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -208,6 +208,19 @@
   "configurationPaletteLabel": "Paleta de color",
   "configurationPaletteHint": "Elige los tonos suaves que prefieras",
   "configurationChangeConfirmation": "Actualizado",
+  "configurationImportLegacyButton": "Importar CSV legado",
+  "configurationImportLegacyLoading": "Importando registros...",
+  "configurationImportNoBaby": "Selecciona un bebé antes de importar.",
+  "configurationImportEmpty": "No encontramos registros válidos en el archivo.",
+  "configurationImportSuccess": "{count, plural, =0{No se importaron registros.} =1{Se importó 1 registro.} other{Se importaron {count} registros.}}",
+  "@configurationImportSuccess": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "configurationImportFailure": "No se pudo importar el archivo. Revisa el formato e inténtalo de nuevo.",
   "configurationPaletteDawnBlush": "Amanecer rosado",
   "configurationPaletteMintWhisper": "Brisa de menta",
   "configurationPaletteSkyBreeze": "Cielo suave",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1088,6 +1088,42 @@ abstract class AppLocalizations {
   /// **'Actualizado'**
   String get configurationChangeConfirmation;
 
+  /// No description provided for @configurationImportLegacyButton.
+  ///
+  /// In es, this message translates to:
+  /// **'Importar CSV legado'**
+  String get configurationImportLegacyButton;
+
+  /// No description provided for @configurationImportLegacyLoading.
+  ///
+  /// In es, this message translates to:
+  /// **'Importando registros...'**
+  String get configurationImportLegacyLoading;
+
+  /// No description provided for @configurationImportNoBaby.
+  ///
+  /// In es, this message translates to:
+  /// **'Selecciona un bebé antes de importar.'**
+  String get configurationImportNoBaby;
+
+  /// No description provided for @configurationImportEmpty.
+  ///
+  /// In es, this message translates to:
+  /// **'No encontramos registros válidos en el archivo.'**
+  String get configurationImportEmpty;
+
+  /// No description provided for @configurationImportSuccess.
+  ///
+  /// In es, this message translates to:
+  /// **'{count, plural, =0{No se importaron registros.} =1{Se importó 1 registro.} other{Se importaron {count} registros.}}'**
+  String configurationImportSuccess(int count);
+
+  /// No description provided for @configurationImportFailure.
+  ///
+  /// In es, this message translates to:
+  /// **'No se pudo importar el archivo. Revisa el formato e inténtalo de nuevo.'**
+  String get configurationImportFailure;
+
   /// No description provided for @configurationPaletteDawnBlush.
   ///
   /// In es, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -551,6 +551,35 @@ class AppLocalizationsEn extends AppLocalizations {
   String get configurationChangeConfirmation => 'Updated';
 
   @override
+  String get configurationImportLegacyButton => 'Import legacy CSV';
+
+  @override
+  String get configurationImportLegacyLoading => 'Importing records...';
+
+  @override
+  String get configurationImportNoBaby =>
+      'Select a baby before importing.';
+
+  @override
+  String get configurationImportEmpty =>
+      "We couldn't find compatible records in the file.";
+
+  @override
+  String configurationImportSuccess(int count) {
+    return intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      zero: 'No records were imported.',
+      one: '1 record imported.',
+      other: '$count records imported.',
+    );
+  }
+
+  @override
+  String get configurationImportFailure =>
+      "We couldn't import the file. Check the format and try again.";
+
+  @override
   String get configurationPaletteDawnBlush => 'Blush sunrise';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -555,6 +555,35 @@ class AppLocalizationsEs extends AppLocalizations {
   String get configurationChangeConfirmation => 'Actualizado';
 
   @override
+  String get configurationImportLegacyButton => 'Importar CSV legado';
+
+  @override
+  String get configurationImportLegacyLoading => 'Importando registros...';
+
+  @override
+  String get configurationImportNoBaby =>
+      'Selecciona un bebé antes de importar.';
+
+  @override
+  String get configurationImportEmpty =>
+      'No encontramos registros válidos en el archivo.';
+
+  @override
+  String configurationImportSuccess(int count) {
+    return intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      zero: 'No se importaron registros.',
+      one: 'Se importó 1 registro.',
+      other: 'Se importaron $count registros.',
+    );
+  }
+
+  @override
+  String get configurationImportFailure =>
+      'No se pudo importar el archivo. Revisa el formato e inténtalo de nuevo.';
+
+  @override
   String get configurationPaletteDawnBlush => 'Amanecer rosado';
 
   @override

--- a/lib/presentation/features/settings/configuration_screen.dart
+++ b/lib/presentation/features/settings/configuration_screen.dart
@@ -1,14 +1,29 @@
-﻿import 'package:flutter/material.dart';
+import 'dart:convert';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:pequelog/data/baby_actions/legacy_action_csv_parser.dart';
+import 'package:pequelog/domain/baby_actions/entities/stool_texture.dart';
+import 'package:pequelog/domain/baby_actions/entities/vomit_severity.dart';
 import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/app_settings.dart';
+import 'package:pequelog/presentation/features/baby_actions/baby_actions_state.dart';
+import 'package:pequelog/presentation/features/startup/baby_state.dart';
 import 'package:pequelog/presentation/theme/app_color_palettes.dart';
 import 'package:provider/provider.dart';
 
 /// Simple configuration screen for language and color palette selection.
-class ConfigurationScreen extends StatelessWidget {
+class ConfigurationScreen extends StatefulWidget {
   /// Creates the configuration screen.
   const ConfigurationScreen({super.key});
+
+  @override
+  State<ConfigurationScreen> createState() => _ConfigurationScreenState();
+}
+
+class _ConfigurationScreenState extends State<ConfigurationScreen> {
+  bool _isImporting = false;
 
   @override
   Widget build(BuildContext context) {
@@ -26,6 +41,36 @@ class ConfigurationScreen extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                FilledButton.icon(
+                  onPressed: () {
+                    if (_isImporting) {
+                      return;
+                    }
+                    _importLegacyCsv(context);
+                  },
+                  icon: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 200),
+                    child: _isImporting
+                        ? SizedBox(
+                            key: const ValueKey('loading'),
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                theme.colorScheme.onPrimary,
+                              ),
+                            ),
+                          )
+                        : const Icon(Icons.upload_file_outlined),
+                  ),
+                  label: Text(
+                    _isImporting
+                        ? l10n.configurationImportLegacyLoading
+                        : l10n.configurationImportLegacyButton,
+                  ),
+                ),
+                const SizedBox(height: 32),
                 Text(
                   l10n.configurationThemeModeLabel,
                   style: theme.textTheme.titleMedium?.copyWith(
@@ -61,7 +106,10 @@ class ConfigurationScreen extends StatelessWidget {
                   onTap: () {
                     HapticFeedback.selectionClick();
                     settings.setLocale(const Locale('es'));
-                    _showChangeSnackBar(context, l10n.configurationLanguageSpanish);
+                    _showChangeSnackBar(
+                      context,
+                      l10n.configurationLanguageSpanish,
+                    );
                   },
                 ),
                 const SizedBox(height: 8),
@@ -72,11 +120,12 @@ class ConfigurationScreen extends StatelessWidget {
                   onTap: () {
                     HapticFeedback.selectionClick();
                     settings.setLocale(const Locale('en'));
-                    _showChangeSnackBar(context, l10n.configurationLanguageEnglish);
+                    _showChangeSnackBar(
+                      context,
+                      l10n.configurationLanguageEnglish,
+                    );
                   },
                 ),
-                const SizedBox(height: 16),
-                _LanguagePreviewCard(locale: settings.locale),
                 const SizedBox(height: 32),
                 Text(
                   l10n.configurationPaletteLabel,
@@ -92,7 +141,10 @@ class ConfigurationScreen extends StatelessWidget {
                   onTap: () {
                     HapticFeedback.selectionClick();
                     settings.setPalette(AppColorPalette.dawnBlush);
-                    _showChangeSnackBar(context, l10n.configurationPaletteDawnBlush);
+                    _showChangeSnackBar(
+                      context,
+                      l10n.configurationPaletteDawnBlush,
+                    );
                   },
                 ),
                 const SizedBox(height: 8),
@@ -103,7 +155,10 @@ class ConfigurationScreen extends StatelessWidget {
                   onTap: () {
                     HapticFeedback.selectionClick();
                     settings.setPalette(AppColorPalette.mintWhisper);
-                    _showChangeSnackBar(context, l10n.configurationPaletteMintWhisper);
+                    _showChangeSnackBar(
+                      context,
+                      l10n.configurationPaletteMintWhisper,
+                    );
                   },
                 ),
                 const SizedBox(height: 8),
@@ -114,7 +169,10 @@ class ConfigurationScreen extends StatelessWidget {
                   onTap: () {
                     HapticFeedback.selectionClick();
                     settings.setPalette(AppColorPalette.skyBreeze);
-                    _showChangeSnackBar(context, l10n.configurationPaletteSkyBreeze);
+                    _showChangeSnackBar(
+                      context,
+                      l10n.configurationPaletteSkyBreeze,
+                    );
                   },
                 ),
                 const SizedBox(height: 8),
@@ -125,13 +183,155 @@ class ConfigurationScreen extends StatelessWidget {
                   onTap: () {
                     HapticFeedback.selectionClick();
                     settings.setPalette(AppColorPalette.lavenderField);
-                    _showChangeSnackBar(context, l10n.configurationPaletteLavenderField);
+                    _showChangeSnackBar(
+                      context,
+                      l10n.configurationPaletteLavenderField,
+                    );
                   },
                 ),
               ],
             ),
           );
         },
+      ),
+    );
+  }
+
+  Future<void> _importLegacyCsv(BuildContext context) async {
+    final l10n = AppLocalizations.of(context)!;
+    final babyState = context.read<BabyState>();
+    final baby = babyState.selectedBaby;
+    if (baby == null) {
+      _showImportSnackBar(context, l10n.configurationImportNoBaby, isError: true);
+      return;
+    }
+
+    setState(() {
+      _isImporting = true;
+    });
+
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: const <String>['csv'],
+        withData: true,
+      );
+
+      if (!mounted) {
+        return;
+      }
+
+      if (result == null || result.files.isEmpty) {
+        return;
+      }
+
+      final file = result.files.first;
+      final bytes = file.bytes;
+      if (bytes == null) {
+        _showImportSnackBar(
+          context,
+          l10n.configurationImportFailure,
+          isError: true,
+        );
+        return;
+      }
+
+      final parser = LegacyActionCsvParser();
+      final records = parser.parse(utf8.decode(bytes));
+      if (records.isEmpty) {
+        _showImportSnackBar(
+          context,
+          l10n.configurationImportEmpty,
+          isError: true,
+        );
+        return;
+      }
+
+      final actionsState = context.read<BabyActionsState>();
+      var inserted = 0;
+      for (final record in records) {
+        if (!mounted) {
+          return;
+        }
+        if (record.feedAmountMl != null) {
+          await actionsState.logFeed(
+            occurredAt: record.occurredAt,
+            amountMl: record.feedAmountMl!,
+          );
+          inserted++;
+        }
+        if (record.didPoop) {
+          await actionsState.logDiaper(
+            occurredAt: record.occurredAt,
+            texture: StoolTexture.soft,
+          );
+          inserted++;
+        }
+        if (record.didVomit) {
+          await actionsState.logVomit(
+            occurredAt: record.occurredAt,
+            severity: VomitSeverity.mild,
+          );
+          inserted++;
+        }
+        if (record.didBath) {
+          await actionsState.logBath(
+            occurredAt: record.occurredAt,
+          );
+          inserted++;
+        }
+      }
+
+      if (!mounted) {
+        return;
+      }
+
+      _showImportSnackBar(
+        context,
+        l10n.configurationImportSuccess(inserted),
+      );
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      _showImportSnackBar(
+        context,
+        l10n.configurationImportFailure,
+        isError: true,
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isImporting = false;
+        });
+      }
+    }
+  }
+
+  void _showImportSnackBar(
+    BuildContext context,
+    String message, {
+    bool isError = false,
+  }) {
+    final theme = Theme.of(context);
+    final backgroundColor =
+        isError ? theme.colorScheme.error : theme.colorScheme.primary;
+    final foregroundColor =
+        isError ? theme.colorScheme.onError : theme.colorScheme.onPrimary;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: TextStyle(color: foregroundColor),
+        ),
+        backgroundColor: backgroundColor,
+        duration: const Duration(seconds: 3),
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.all(16),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
       ),
     );
   }
@@ -250,45 +450,45 @@ class _PaletteOption extends StatelessWidget {
             child: InkWell(
               onTap: onTap,
               borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            children: [
-              Icon(
-                isSelected
-                    ? Icons.radio_button_checked
-                    : Icons.radio_button_unchecked,
-                color: isSelected
-                    ? theme.colorScheme.primary
-                    : theme.colorScheme.onSurface.withOpacity(0.6),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Text(
-                  title,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontWeight:
-                        isSelected ? FontWeight.w600 : FontWeight.normal,
-                    color: isSelected
-                        ? theme.colorScheme.onSurface
-                        : theme.colorScheme.onSurface.withOpacity(0.87),
-                  ),
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Icon(
+                      isSelected
+                          ? Icons.radio_button_checked
+                          : Icons.radio_button_unchecked,
+                      color: isSelected
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurface.withOpacity(0.6),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          fontWeight:
+                              isSelected ? FontWeight.w600 : FontWeight.normal,
+                          color: isSelected
+                              ? theme.colorScheme.onSurface
+                              : theme.colorScheme.onSurface.withOpacity(0.87),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _ColorDot(color: colors.background),
+                        const SizedBox(width: 6),
+                        _ColorDot(color: colors.surface),
+                        const SizedBox(width: 6),
+                        _ColorDot(color: colors.accent),
+                      ],
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(width: 16),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  _ColorDot(color: colors.background),
-                  const SizedBox(width: 6),
-                  _ColorDot(color: colors.surface),
-                  const SizedBox(width: 6),
-                  _ColorDot(color: colors.accent),
-                ],
-              ),
-            ],
-          ),
-        ),
             ),
           ),
         ),
@@ -319,78 +519,6 @@ class _ColorDot extends StatelessWidget {
   }
 }
 
-/// Preview card showing example text in the selected language.
-class _LanguagePreviewCard extends StatelessWidget {
-  const _LanguagePreviewCard({required this.locale});
-
-  final Locale locale;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isSpanish = locale.languageCode == 'es';
-
-    return Container(
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest.withOpacity(0.3),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: theme.colorScheme.outline.withOpacity(0.2),
-          width: 1,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(
-                Icons.translate_rounded,
-                size: 18,
-                color: theme.colorScheme.primary,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                isSpanish ? 'Vista previa' : 'Preview',
-                style: theme.textTheme.labelMedium?.copyWith(
-                  color: theme.colorScheme.primary,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          Text(
-            isSpanish ? '¡Hola! Bienvenido a PequeLog' : 'Hello! Welcome to PequeLog',
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            isSpanish
-                ? 'Registra las actividades diarias de tu bebé'
-                : 'Track your baby\'s daily activities',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.7),
-            ),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            isSpanish
-                ? 'Comida, pañales, baños y más'
-                : 'Feeding, diapers, baths and more',
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurface.withOpacity(0.7),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 /// Segmented button for theme mode selection with animated icons.
 class _ThemeModeSegmentedButton extends StatelessWidget {
   const _ThemeModeSegmentedButton({
@@ -410,53 +538,47 @@ class _ThemeModeSegmentedButton extends StatelessWidget {
       segments: [
         ButtonSegment(
           value: ThemeMode.light,
-          label: Text(l10n.configurationThemeModeLight),
-          icon: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 300),
-            child: Icon(
-              Icons.wb_sunny_rounded,
-              key: const ValueKey('sun'),
-              color: currentMode == ThemeMode.light
-                  ? theme.colorScheme.primary
-                  : theme.colorScheme.onSurface.withOpacity(0.6),
-            ),
+          label: const SizedBox.shrink(),
+          icon: Icon(
+            Icons.wb_sunny_rounded,
+            color: currentMode == ThemeMode.light
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurface.withOpacity(0.6),
           ),
+          tooltip: l10n.configurationThemeModeLight,
         ),
         ButtonSegment(
           value: ThemeMode.system,
-          label: Text(l10n.configurationThemeModeSystem),
-          icon: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 300),
-            child: Icon(
-              Icons.brightness_auto_rounded,
-              key: const ValueKey('auto'),
-              color: currentMode == ThemeMode.system
-                  ? theme.colorScheme.primary
-                  : theme.colorScheme.onSurface.withOpacity(0.6),
-            ),
+          label: const SizedBox.shrink(),
+          icon: Icon(
+            Icons.brightness_auto_rounded,
+            color: currentMode == ThemeMode.system
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurface.withOpacity(0.6),
           ),
+          tooltip: l10n.configurationThemeModeSystem,
         ),
         ButtonSegment(
           value: ThemeMode.dark,
-          label: Text(l10n.configurationThemeModeDark),
-          icon: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 300),
-            child: Icon(
-              Icons.nights_stay_rounded,
-              key: const ValueKey('moon'),
-              color: currentMode == ThemeMode.dark
-                  ? theme.colorScheme.primary
-                  : theme.colorScheme.onSurface.withOpacity(0.6),
-            ),
+          label: const SizedBox.shrink(),
+          icon: Icon(
+            Icons.nights_stay_rounded,
+            color: currentMode == ThemeMode.dark
+                ? theme.colorScheme.primary
+                : theme.colorScheme.onSurface.withOpacity(0.6),
           ),
+          tooltip: l10n.configurationThemeModeDark,
         ),
       ],
       selected: {currentMode},
       onSelectionChanged: (Set<ThemeMode> selected) {
         onModeChanged(selected.first);
       },
-      style: ButtonStyle(
+      style: const ButtonStyle(
         visualDensity: VisualDensity.comfortable,
+        padding: MaterialStatePropertyAll<EdgeInsets>(
+          EdgeInsets.symmetric(horizontal: 12),
+        ),
       ),
     );
   }
@@ -466,7 +588,7 @@ class _ThemeModeSegmentedButton extends StatelessWidget {
 void _showChangeSnackBar(BuildContext context, String changeName) {
   final theme = Theme.of(context);
   final l10n = AppLocalizations.of(context)!;
-  
+
   ScaffoldMessenger.of(context).showSnackBar(
     SnackBar(
       content: Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   path: ^1.9.0
   shared_preferences: ^2.2.2
   go_router: ^14.6.2
+  file_picker: ^8.1.2
 
 
 dev_dependencies:

--- a/test/unit/data/legacy_action_csv_parser_test.dart
+++ b/test/unit/data/legacy_action_csv_parser_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pequelog/data/baby_actions/legacy_action_csv_parser.dart';
+
+void main() {
+  group('LegacyActionCsvParser', () {
+    test('parses feed, vomit and bath flags from UTF-8 CSV', () {
+      const csv = 'Fecha,Hora,Biberón (ml),Caca,Vómito,Baño\n'
+          '2025-10-02,08:20,140,,Sí,\n';
+      final parser = LegacyActionCsvParser();
+
+      final records = parser.parse(csv);
+
+      expect(records, hasLength(1));
+      final record = records.single;
+      expect(record.feedAmountMl, 140);
+      expect(record.didPoop, isFalse);
+      expect(record.didVomit, isTrue);
+      expect(record.didBath, isFalse);
+      expect(record.occurredAt, DateTime(2025, 10, 2, 8, 20));
+    });
+
+    test('parses latin1 artifacts as positive flags', () {
+      const csv = 'Fecha,Hora,Biberón (ml),Caca,Vómito,Baño\n'
+          '2025-10-02,08:20,,SÃ­,,,\n';
+      final parser = LegacyActionCsvParser();
+
+      final records = parser.parse(csv);
+
+      expect(records, hasLength(1));
+      final record = records.single;
+      expect(record.feedAmountMl, isNull);
+      expect(record.didPoop, isTrue);
+      expect(record.didVomit, isFalse);
+      expect(record.didBath, isFalse);
+    });
+
+    test('ignores rows without actionable information', () {
+      const csv = 'Fecha,Hora,Biberón (ml),Caca,Vómito,Baño\n'
+          '2025-10-02,08:20,,,,\n';
+      final parser = LegacyActionCsvParser();
+
+      final records = parser.parse(csv);
+
+      expect(records, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a temporary CSV importer on the configuration screen that splits legacy rows into individual baby actions
- parse the legacy export format into structured records and surface localized feedback messages
- simplify the theme mode control to icon-only buttons while removing the language preview card

## Testing
- `flutter test` *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e39ee175c883328f55cc8e77144ff4