### PR TITLE
fix: defer localization lookup in timeline item

### DIFF
--- a/lib/presentation/widgets/action_timeline_item.dart
+++ b/lib/presentation/widgets/action_timeline_item.dart
@@ -40,14 +40,27 @@ class ActionTimelineItem extends StatefulWidget {
 class _ActionTimelineItemState extends State<ActionTimelineItem> {
   Timer? _timer;
   String _relativeTime = '';
+  bool _hasInitialized = false;
 
   @override
   void initState() {
     super.initState();
-    _updateRelativeTime();
     _timer = Timer.periodic(const Duration(minutes: 1), (_) {
       _updateRelativeTime();
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_hasInitialized) {
+      _updateRelativeTime();
+    } else {
+      final l10n = AppLocalizations.of(context)!;
+      _relativeTime =
+          RelativeTimeFormatter.format(widget.action.occurredAt, l10n);
+      _hasInitialized = true;
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- avoid retrieving inherited localizations during `initState` in `ActionTimelineItem`
- initialize the relative time once dependencies are available and refresh on changes

## Testing
- not run (Flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e3dd224a488332a7a7b70ba4a60aa9