### PR TITLE
fix: enable statistics navigation from baby home

### DIFF
--- a/lib/presentation/features/startup/baby_home_screen.dart
+++ b/lib/presentation/features/startup/baby_home_screen.dart
@@ -237,8 +237,7 @@ class BabyHomeScreen extends StatelessWidget {
   }
 
   void _openStatistics(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    _openFeatureComingSoon(context, l10n.babyActionStatistics);
+    context.goToStatistics();
   }
 
   void _openAskPediatrician(BuildContext context) {


### PR DESCRIPTION
## Summary
- replace the placeholder "coming soon" handler for statistics with real navigation to the statistics route

## Testing
- flutter test *(fails: Flutter SDK not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e3f126f09c8332b57b7ec92e00cdb6