### PR TITLE
Add range filters and custom start date selection to statistics

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -362,6 +362,7 @@
   "statisticsTitle": "Statistics",
   "statisticsRefresh": "Refresh",
   "statisticsDailySummary": "Daily Summary",
+  "statisticsPeriodSummary": "Period summary",
   "statisticsFeedingTitle": "Feeding",
   "statisticsFeedingCount": "{count, plural, =1{1 feed} other{{count} feeds}}",
   "@statisticsFeedingCount": {
@@ -390,13 +391,37 @@
   "statisticsIntervalsTitle": "Intervals",
   "statisticsAverageInterval": "average",
   "statisticsRange": "Range",
+  "statisticsRangeLabel": "Selected range: {range}",
+  "@statisticsRangeLabel": {
+    "placeholders": {
+      "range": {
+        "type": "String"
+      }
+    }
+  },
+  "statisticsRangeLast7Days": "Last 7 days",
+  "statisticsRangeLast14Days": "Last 14 days",
+  "statisticsRangeLast30Days": "Last 30 days",
+  "statisticsRangeCustom": "Custom",
+  "statisticsSelectStartDate": "Choose start date",
+  "statisticsCustomStartLabel": "From {date}",
+  "@statisticsCustomStartLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "statisticsWeeklyChartTitle": "Last 7 days",
+  "statisticsTrendChartTitle": "Trend over time",
   "statisticsVolume": "Volume (ml)",
   "statisticsFeeds": "Feeds",
-  "statisticsComparisonTitle": "Today vs Yesterday",
+  "statisticsComparisonTitle": "Current vs previous period",
   "statisticsAveragePerFeed": "Average per feed",
   "statisticsToday": "Today",
   "statisticsYesterday": "Yesterday",
+  "statisticsCurrentPeriod": "Current period",
+  "statisticsPreviousPeriod": "Previous period",
   "statisticsEmptyTitle": "No records yet today",
   "statisticsEmptyMessage": "Start by recording the first action of the day"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -362,6 +362,7 @@
   "statisticsTitle": "Estadísticas",
   "statisticsRefresh": "Actualizar",
   "statisticsDailySummary": "Resumen del día",
+  "statisticsPeriodSummary": "Resumen del periodo",
   "statisticsFeedingTitle": "Alimentación",
   "statisticsFeedingCount": "{count, plural, =1{1 toma} other{{count} tomas}}",
   "@statisticsFeedingCount": {
@@ -390,13 +391,37 @@
   "statisticsIntervalsTitle": "Intervalos",
   "statisticsAverageInterval": "promedio",
   "statisticsRange": "Rango",
+  "statisticsRangeLabel": "Rango seleccionado: {range}",
+  "@statisticsRangeLabel": {
+    "placeholders": {
+      "range": {
+        "type": "String"
+      }
+    }
+  },
+  "statisticsRangeLast7Days": "Últimos 7 días",
+  "statisticsRangeLast14Days": "Últimos 14 días",
+  "statisticsRangeLast30Days": "Último mes",
+  "statisticsRangeCustom": "Personalizado",
+  "statisticsSelectStartDate": "Elegir fecha de inicio",
+  "statisticsCustomStartLabel": "Desde {date}",
+  "@statisticsCustomStartLabel": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
   "statisticsWeeklyChartTitle": "Últimos 7 días",
+  "statisticsTrendChartTitle": "Tendencia del periodo",
   "statisticsVolume": "Volumen (ml)",
   "statisticsFeeds": "Tomas",
-  "statisticsComparisonTitle": "Hoy vs Ayer",
+  "statisticsComparisonTitle": "Periodo actual vs anterior",
   "statisticsAveragePerFeed": "Promedio por toma",
   "statisticsToday": "Hoy",
   "statisticsYesterday": "Ayer",
+  "statisticsCurrentPeriod": "Periodo actual",
+  "statisticsPreviousPeriod": "Periodo anterior",
   "statisticsEmptyTitle": "Aún no hay registros hoy",
   "statisticsEmptyMessage": "Comienza registrando la primera acción del día"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1406,6 +1406,12 @@ abstract class AppLocalizations {
   /// **'Resumen del día'**
   String get statisticsDailySummary;
 
+  /// No description provided for @statisticsPeriodSummary.
+  ///
+  /// In es, this message translates to:
+  /// **'Resumen del periodo'**
+  String get statisticsPeriodSummary;
+
   /// No description provided for @statisticsFeedingTitle.
   ///
   /// In es, this message translates to:
@@ -1490,11 +1496,59 @@ abstract class AppLocalizations {
   /// **'Rango'**
   String get statisticsRange;
 
+  /// No description provided for @statisticsRangeLabel.
+  ///
+  /// In es, this message translates to:
+  /// **'Rango seleccionado: {range}'**
+  String statisticsRangeLabel(String range);
+
+  /// No description provided for @statisticsRangeLast7Days.
+  ///
+  /// In es, this message translates to:
+  /// **'Últimos 7 días'**
+  String get statisticsRangeLast7Days;
+
+  /// No description provided for @statisticsRangeLast14Days.
+  ///
+  /// In es, this message translates to:
+  /// **'Últimos 14 días'**
+  String get statisticsRangeLast14Days;
+
+  /// No description provided for @statisticsRangeLast30Days.
+  ///
+  /// In es, this message translates to:
+  /// **'Último mes'**
+  String get statisticsRangeLast30Days;
+
+  /// No description provided for @statisticsRangeCustom.
+  ///
+  /// In es, this message translates to:
+  /// **'Personalizado'**
+  String get statisticsRangeCustom;
+
+  /// No description provided for @statisticsSelectStartDate.
+  ///
+  /// In es, this message translates to:
+  /// **'Elegir fecha de inicio'**
+  String get statisticsSelectStartDate;
+
+  /// No description provided for @statisticsCustomStartLabel.
+  ///
+  /// In es, this message translates to:
+  /// **'Desde {date}'**
+  String statisticsCustomStartLabel(String date);
+
   /// No description provided for @statisticsWeeklyChartTitle.
   ///
   /// In es, this message translates to:
   /// **'Últimos 7 días'**
   String get statisticsWeeklyChartTitle;
+
+  /// No description provided for @statisticsTrendChartTitle.
+  ///
+  /// In es, this message translates to:
+  /// **'Tendencia del periodo'**
+  String get statisticsTrendChartTitle;
 
   /// No description provided for @statisticsVolume.
   ///
@@ -1511,7 +1565,7 @@ abstract class AppLocalizations {
   /// No description provided for @statisticsComparisonTitle.
   ///
   /// In es, this message translates to:
-  /// **'Hoy vs Ayer'**
+  /// **'Periodo actual vs anterior'**
   String get statisticsComparisonTitle;
 
   /// No description provided for @statisticsAveragePerFeed.
@@ -1531,6 +1585,18 @@ abstract class AppLocalizations {
   /// In es, this message translates to:
   /// **'Ayer'**
   String get statisticsYesterday;
+
+  /// No description provided for @statisticsCurrentPeriod.
+  ///
+  /// In es, this message translates to:
+  /// **'Periodo actual'**
+  String get statisticsCurrentPeriod;
+
+  /// No description provided for @statisticsPreviousPeriod.
+  ///
+  /// In es, this message translates to:
+  /// **'Periodo anterior'**
+  String get statisticsPreviousPeriod;
 
   /// No description provided for @statisticsEmptyTitle.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -791,6 +791,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statisticsDailySummary => 'Daily Summary';
 
   @override
+  String get statisticsPeriodSummary => 'Period summary';
+
+  @override
   String get statisticsFeedingTitle => 'Feeding';
 
   @override
@@ -849,7 +852,35 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statisticsRange => 'Range';
 
   @override
+  String statisticsRangeLabel(String range) {
+    return 'Selected range: $range';
+  }
+
+  @override
+  String get statisticsRangeLast7Days => 'Last 7 days';
+
+  @override
+  String get statisticsRangeLast14Days => 'Last 14 days';
+
+  @override
+  String get statisticsRangeLast30Days => 'Last 30 days';
+
+  @override
+  String get statisticsRangeCustom => 'Custom';
+
+  @override
+  String get statisticsSelectStartDate => 'Choose start date';
+
+  @override
+  String statisticsCustomStartLabel(String date) {
+    return 'From $date';
+  }
+
+  @override
   String get statisticsWeeklyChartTitle => 'Last 7 days';
+
+  @override
+  String get statisticsTrendChartTitle => 'Trend over time';
 
   @override
   String get statisticsVolume => 'Volume (ml)';
@@ -858,7 +889,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get statisticsFeeds => 'Feeds';
 
   @override
-  String get statisticsComparisonTitle => 'Today vs Yesterday';
+  String get statisticsComparisonTitle => 'Current vs previous period';
 
   @override
   String get statisticsAveragePerFeed => 'Average per feed';
@@ -868,6 +899,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get statisticsYesterday => 'Yesterday';
+
+  @override
+  String get statisticsCurrentPeriod => 'Current period';
+
+  @override
+  String get statisticsPreviousPeriod => 'Previous period';
 
   @override
   String get statisticsEmptyTitle => 'No records yet today';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -796,6 +796,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statisticsDailySummary => 'Resumen del día';
 
   @override
+  String get statisticsPeriodSummary => 'Resumen del periodo';
+
+  @override
   String get statisticsFeedingTitle => 'Alimentación';
 
   @override
@@ -854,7 +857,35 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statisticsRange => 'Rango';
 
   @override
+  String statisticsRangeLabel(String range) {
+    return 'Rango seleccionado: $range';
+  }
+
+  @override
+  String get statisticsRangeLast7Days => 'Últimos 7 días';
+
+  @override
+  String get statisticsRangeLast14Days => 'Últimos 14 días';
+
+  @override
+  String get statisticsRangeLast30Days => 'Último mes';
+
+  @override
+  String get statisticsRangeCustom => 'Personalizado';
+
+  @override
+  String get statisticsSelectStartDate => 'Elegir fecha de inicio';
+
+  @override
+  String statisticsCustomStartLabel(String date) {
+    return 'Desde $date';
+  }
+
+  @override
   String get statisticsWeeklyChartTitle => 'Últimos 7 días';
+
+  @override
+  String get statisticsTrendChartTitle => 'Tendencia del periodo';
 
   @override
   String get statisticsVolume => 'Volumen (ml)';
@@ -863,7 +894,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get statisticsFeeds => 'Tomas';
 
   @override
-  String get statisticsComparisonTitle => 'Hoy vs Ayer';
+  String get statisticsComparisonTitle => 'Periodo actual vs anterior';
 
   @override
   String get statisticsAveragePerFeed => 'Promedio por toma';
@@ -873,6 +904,12 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get statisticsYesterday => 'Ayer';
+
+  @override
+  String get statisticsCurrentPeriod => 'Periodo actual';
+
+  @override
+  String get statisticsPreviousPeriod => 'Periodo anterior';
 
   @override
   String get statisticsEmptyTitle => 'Aún no hay registros hoy';

--- a/lib/presentation/features/statistics/statistics_screen.dart
+++ b/lib/presentation/features/statistics/statistics_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart' as intl;
 import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/statistics/statistics_state.dart';
 import 'package:pequelog/presentation/features/statistics/widgets/comparison_widget.dart';
@@ -35,6 +36,20 @@ class StatisticsScreen extends StatelessWidget {
             );
           }
 
+          final locale = Localizations.localeOf(context);
+          final dateFormatter = intl.DateFormat.yMMMd(locale.toLanguageTag());
+          final currentRangeText =
+              '${dateFormatter.format(state.currentRangeStart)} – ${dateFormatter.format(_stripTime(state.currentRangeEnd))}';
+          final previousRangeText = state.previousRangeStart != null &&
+                  state.previousRangeEnd != null
+              ? '${dateFormatter.format(_stripTime(state.previousRangeStart!))} – ${dateFormatter.format(_stripTime(state.previousRangeEnd!))}'
+              : null;
+
+          final currentLabel = '${l10n.statisticsCurrentPeriod}\n$currentRangeText';
+          final previousLabel = previousRangeText != null
+              ? '${l10n.statisticsPreviousPeriod}\n$previousRangeText'
+              : l10n.statisticsPreviousPeriod;
+
           return RefreshIndicator(
             onRefresh: () => state.reload(),
             child: SingleChildScrollView(
@@ -43,41 +58,144 @@ class StatisticsScreen extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const SizedBox(height: 16),
-                  
+
+                  _StatisticsFilterBar(l10n: l10n),
+
+                  const SizedBox(height: 16),
+
                   // Daily Summary Cards
                   DailySummaryCards(
-                    metrics: state.todayMetrics,
+                    metrics: state.currentPeriodMetrics,
+                    title: l10n.statisticsPeriodSummary,
+                    subtitle: l10n.statisticsRangeLabel(currentRangeText),
                   ),
-                  
+
                   const SizedBox(height: 32),
-                  
+
                   // Weekly Bar Chart
                   WeeklyBarChart(
                     data: state.weeklyData,
                   ),
-                  
+
                   const SizedBox(height: 32),
-                  
+
                   // Comparison: Today vs Yesterday
-                  ComparisonWidget(
-                    todayMetrics: state.todayMetrics,
-                    yesterdayMetrics: state.yesterdayMetrics,
-                  ),
-                  
+                  if (state.hasPreviousPeriod)
+                    ComparisonWidget(
+                      currentMetrics: state.currentPeriodMetrics,
+                      previousMetrics: state.previousPeriodMetrics,
+                      currentLabel: currentLabel,
+                      previousLabel: previousLabel,
+                      showTrends: state.hasPreviousPeriod,
+                    ),
+
                   const SizedBox(height: 32),
-                  
+
                   // Empty state for no data
-                  if (state.todayMetrics.feedCount == 0 &&
-                      state.todayMetrics.diaperCount == 0 &&
-                      state.todayMetrics.bathCount == 0)
+                  if (state.currentPeriodMetrics.feedCount == 0 &&
+                      state.currentPeriodMetrics.diaperCount == 0 &&
+                      state.currentPeriodMetrics.bathCount == 0)
                     _EmptyState(l10n: l10n),
-                  
+
                   const SizedBox(height: 16),
                 ],
               ),
             ),
           );
         },
+      ),
+    );
+  }
+
+  DateTime _stripTime(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
+  }
+}
+
+class _StatisticsFilterBar extends StatelessWidget {
+  const _StatisticsFilterBar({
+    required this.l10n,
+  });
+
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final state = context.watch<StatisticsState>();
+    final locale = Localizations.localeOf(context);
+    final dateFormatter = intl.DateFormat.yMMMd(locale.toLanguageTag());
+    final customLabel = state.customStartDate != null
+        ? dateFormatter.format(state.customStartDate!)
+        : null;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SegmentedButton<StatisticsRange>(
+            segments: [
+              ButtonSegment(
+                value: StatisticsRange.last7Days,
+                label: Text(l10n.statisticsRangeLast7Days),
+              ),
+              ButtonSegment(
+                value: StatisticsRange.last14Days,
+                label: Text(l10n.statisticsRangeLast14Days),
+              ),
+              ButtonSegment(
+                value: StatisticsRange.last30Days,
+                label: Text(l10n.statisticsRangeLast30Days),
+              ),
+              ButtonSegment(
+                value: StatisticsRange.custom,
+                label: Text(l10n.statisticsRangeCustom),
+              ),
+            ],
+            selected: <StatisticsRange>{state.selectedRange},
+            onSelectionChanged: (selection) async {
+              final selected = selection.first;
+              await context.read<StatisticsState>().updateRange(selected);
+            },
+          ),
+          if (state.selectedRange == StatisticsRange.custom)
+            Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: Wrap(
+                spacing: 12,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  FilledButton.tonal(
+                    onPressed: () async {
+                      final now = DateTime.now();
+                      final initialDate = state.customStartDate ?? state.currentRangeStart;
+                      final pickedDate = await showDatePicker(
+                        context: context,
+                        initialDate: initialDate,
+                        firstDate: DateTime(now.year - 2),
+                        lastDate: now,
+                        helpText: l10n.statisticsSelectStartDate,
+                      );
+                      if (pickedDate != null) {
+                        await context
+                            .read<StatisticsState>()
+                            .updateCustomStartDate(pickedDate);
+                      }
+                    },
+                    child: Text(l10n.statisticsSelectStartDate),
+                  ),
+                  if (customLabel != null)
+                    Text(
+                      l10n.statisticsCustomStartLabel(customLabel),
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/lib/presentation/features/statistics/statistics_state.dart
+++ b/lib/presentation/features/statistics/statistics_state.dart
@@ -3,6 +3,29 @@ import 'package:pequelog/domain/baby_actions/entities/baby_action.dart';
 import 'package:pequelog/domain/baby_actions/entities/baby_action_kind.dart';
 import 'package:pequelog/domain/baby_actions/repositories/baby_action_repository.dart';
 
+/// Available ranges to filter statistics data.
+enum StatisticsRange {
+  last7Days,
+  last14Days,
+  last30Days,
+  custom,
+}
+
+extension on StatisticsRange {
+  int? get daySpan {
+    switch (this) {
+      case StatisticsRange.last7Days:
+        return 7;
+      case StatisticsRange.last14Days:
+        return 14;
+      case StatisticsRange.last30Days:
+        return 30;
+      case StatisticsRange.custom:
+        return null;
+    }
+  }
+}
+
 /// Data class for daily statistics metrics
 class DailyMetrics {
   final int feedCount;
@@ -43,12 +66,12 @@ class DailyMetrics {
   );
 }
 
-/// Data class for weekly bar chart data
+/// Data class for time series chart data
 class WeeklyData {
   final DateTime date;
   final int feedCount;
   final int totalMl;
-  final String dayLabel; // 'L', 'M', 'X', 'J', 'V', 'S', 'D'
+  final String dayLabel;
 
   const WeeklyData({
     required this.date,
@@ -58,15 +81,31 @@ class WeeklyData {
   });
 }
 
+class _DateRange {
+  const _DateRange({
+    required this.start,
+    required this.end,
+  });
+
+  final DateTime start;
+  final DateTime end;
+}
+
 /// State management for statistics screen
 class StatisticsState extends ChangeNotifier {
   final BabyActionRepository _repository;
   final String babyId;
 
   bool _isLoading = false;
-  DailyMetrics _todayMetrics = DailyMetrics.empty;
-  DailyMetrics _yesterdayMetrics = DailyMetrics.empty;
+  StatisticsRange _selectedRange = StatisticsRange.last7Days;
+  DateTime? _customStartDate;
+  DailyMetrics _currentPeriodMetrics = DailyMetrics.empty;
+  DailyMetrics _previousPeriodMetrics = DailyMetrics.empty;
   List<WeeklyData> _weeklyData = [];
+  DateTime _currentRangeStart = DateTime.now();
+  DateTime _currentRangeEnd = DateTime.now();
+  DateTime? _previousRangeStart;
+  DateTime? _previousRangeEnd;
 
   StatisticsState({
     required BabyActionRepository repository,
@@ -76,12 +115,36 @@ class StatisticsState extends ChangeNotifier {
   }
 
   bool get isLoading => _isLoading;
-  DailyMetrics get todayMetrics => _todayMetrics;
-  DailyMetrics get yesterdayMetrics => _yesterdayMetrics;
+  StatisticsRange get selectedRange => _selectedRange;
+  DateTime? get customStartDate => _customStartDate;
+  DailyMetrics get currentPeriodMetrics => _currentPeriodMetrics;
+  DailyMetrics get previousPeriodMetrics => _previousPeriodMetrics;
   List<WeeklyData> get weeklyData => _weeklyData;
+  DateTime get currentRangeStart => _currentRangeStart;
+  DateTime get currentRangeEnd => _currentRangeEnd;
+  DateTime? get previousRangeStart => _previousRangeStart;
+  DateTime? get previousRangeEnd => _previousRangeEnd;
+  bool get hasPreviousPeriod => _previousRangeStart != null;
 
   /// Reload all statistics
   Future<void> reload() async {
+    await _loadStatistics();
+  }
+
+  Future<void> updateRange(StatisticsRange range) async {
+    if (_selectedRange == range && range != StatisticsRange.custom) {
+      return;
+    }
+    _selectedRange = range;
+    if (range != StatisticsRange.custom) {
+      _customStartDate = null;
+    }
+    await _loadStatistics();
+  }
+
+  Future<void> updateCustomStartDate(DateTime startDate) async {
+    _selectedRange = StatisticsRange.custom;
+    _customStartDate = DateTime(startDate.year, startDate.month, startDate.day);
     await _loadStatistics();
   }
 
@@ -91,9 +154,18 @@ class StatisticsState extends ChangeNotifier {
 
     try {
       final now = DateTime.now();
-      final todayStart = DateTime(now.year, now.month, now.day);
-      final yesterdayStart = todayStart.subtract(const Duration(days: 1));
-      final weekStart = todayStart.subtract(Duration(days: now.weekday - 1));
+      final todayEnd = DateTime(
+        now.year,
+        now.month,
+        now.day,
+        23,
+        59,
+        59,
+        999,
+      );
+      final periodStart = _resolvePeriodStart(todayEnd);
+      _currentRangeStart = periodStart;
+      _currentRangeEnd = todayEnd;
 
       // Parse babyId to int
       final babyIdInt = int.tryParse(babyId);
@@ -103,36 +175,74 @@ class StatisticsState extends ChangeNotifier {
         return;
       }
 
-      // Load today's actions
-      final todayActions = await _repository.fetchFilteredActions(
+      // Load actions for the selected period
+      final currentActions = await _repository.fetchFilteredActions(
         babyIdInt,
-        startDate: todayStart,
-        endDate: now,
+        startDate: periodStart,
+        endDate: todayEnd,
       );
 
-      // Load yesterday's actions
-      final yesterdayActions = await _repository.fetchFilteredActions(
-        babyIdInt,
-        startDate: yesterdayStart,
-        endDate: todayStart,
-      );
+      _currentPeriodMetrics = _calculateMetrics(currentActions);
 
-      // Load weekly actions
-      final weeklyActions = await _repository.fetchFilteredActions(
-        babyIdInt,
-        startDate: weekStart,
-        endDate: now,
-      );
+      final previousRange = _resolvePreviousRange(periodStart, todayEnd);
+      if (previousRange != null) {
+        final previousActions = await _repository.fetchFilteredActions(
+          babyIdInt,
+          startDate: previousRange.start,
+          endDate: previousRange.end,
+        );
+        _previousPeriodMetrics = _calculateMetrics(previousActions);
+        _previousRangeStart = previousRange.start;
+        _previousRangeEnd = previousRange.end;
+      } else {
+        _previousPeriodMetrics = DailyMetrics.empty;
+        _previousRangeStart = null;
+        _previousRangeEnd = null;
+      }
 
-      _todayMetrics = _calculateMetrics(todayActions);
-      _yesterdayMetrics = _calculateMetrics(yesterdayActions);
-      _weeklyData = _calculateWeeklyData(weeklyActions, weekStart);
+      _weeklyData = _calculateWeeklyData(currentActions, periodStart, todayEnd);
     } catch (e) {
       debugPrint('Error loading statistics: $e');
     } finally {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  DateTime _resolvePeriodStart(DateTime todayEnd) {
+    final daySpan = _selectedRange.daySpan;
+    if (_selectedRange == StatisticsRange.custom && _customStartDate != null) {
+      final custom = _customStartDate!;
+      final customStart = DateTime(custom.year, custom.month, custom.day);
+      if (customStart.isAfter(todayEnd)) {
+        return DateTime(todayEnd.year, todayEnd.month, todayEnd.day);
+      }
+      return customStart;
+    }
+
+    final startOfToday = DateTime(todayEnd.year, todayEnd.month, todayEnd.day);
+    if (daySpan == null || daySpan <= 1) {
+      return startOfToday;
+    }
+    return startOfToday.subtract(Duration(days: daySpan - 1));
+  }
+
+  _DateRange? _resolvePreviousRange(DateTime start, DateTime end) {
+    final spanDays = end.difference(start).inDays + 1;
+    if (spanDays <= 1) {
+      return null;
+    }
+
+    final previousPeriodEnd = start.subtract(const Duration(milliseconds: 1));
+    final previousPeriodStart = DateTime(
+      previousPeriodEnd.year,
+      previousPeriodEnd.month,
+      previousPeriodEnd.day,
+    ).subtract(Duration(days: spanDays - 1));
+    return _DateRange(
+      start: previousPeriodStart,
+      end: previousPeriodEnd,
+    );
   }
 
   DailyMetrics _calculateMetrics(List<BabyAction> actions) {
@@ -185,10 +295,13 @@ class StatisticsState extends ChangeNotifier {
     Duration? maxInterval;
 
     if (feedActions.length >= 2) {
+      feedActions.sort(
+        (a, b) => a.occurredAt.compareTo(b.occurredAt),
+      );
       final intervals = <Duration>[];
       for (int i = 0; i < feedActions.length - 1; i++) {
-        final interval = feedActions[i].occurredAt.difference(
-          feedActions[i + 1].occurredAt,
+        final interval = feedActions[i + 1].occurredAt.difference(
+          feedActions[i].occurredAt,
         );
         intervals.add(interval);
       }
@@ -223,13 +336,14 @@ class StatisticsState extends ChangeNotifier {
 
   List<WeeklyData> _calculateWeeklyData(
     List<BabyAction> actions,
-    DateTime weekStart,
+    DateTime periodStart,
+    DateTime periodEnd,
   ) {
     final weeklyMap = <DateTime, List<BabyAction>>{};
 
-    // Initialize all 7 days
-    for (int i = 0; i < 7; i++) {
-      final date = weekStart.add(Duration(days: i));
+    final totalDays = periodEnd.difference(periodStart).inDays;
+    for (int i = 0; i <= totalDays; i++) {
+      final date = periodStart.add(Duration(days: i));
       final dateKey = DateTime(date.year, date.month, date.day);
       weeklyMap[dateKey] = [];
     }
@@ -246,7 +360,6 @@ class StatisticsState extends ChangeNotifier {
 
     // Calculate metrics for each day
     final result = <WeeklyData>[];
-    final dayLabels = ['L', 'M', 'X', 'J', 'V', 'S', 'D'];
 
     weeklyMap.forEach((date, dayActions) {
       int feedCount = 0;
@@ -262,12 +375,11 @@ class StatisticsState extends ChangeNotifier {
         }
       }
 
-      final weekday = date.weekday - 1; // 0-6
       result.add(WeeklyData(
         date: date,
         feedCount: feedCount,
         totalMl: totalMl,
-        dayLabel: dayLabels[weekday],
+        dayLabel: '${date.day}/${date.month}',
       ));
     });
 

--- a/lib/presentation/features/statistics/widgets/comparison_widget.dart
+++ b/lib/presentation/features/statistics/widgets/comparison_widget.dart
@@ -2,16 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/statistics/statistics_state.dart';
 
-/// Widget that displays a comparison between today's and yesterday's metrics
+/// Widget that displays a comparison between the current and previous period metrics
 class ComparisonWidget extends StatelessWidget {
   const ComparisonWidget({
-    required this.todayMetrics,
-    required this.yesterdayMetrics,
+    required this.currentMetrics,
+    required this.previousMetrics,
+    required this.currentLabel,
+    required this.previousLabel,
+    required this.showTrends,
     super.key,
   });
 
-  final DailyMetrics todayMetrics;
-  final DailyMetrics yesterdayMetrics;
+  final DailyMetrics currentMetrics;
+  final DailyMetrics previousMetrics;
+  final String currentLabel;
+  final String previousLabel;
+  final bool showTrends;
 
   @override
   Widget build(BuildContext context) {
@@ -45,37 +51,47 @@ class ComparisonWidget extends StatelessWidget {
               children: [
                 _ComparisonRow(
                   label: l10n.statisticsFeedingTitle,
-                  todayValue: '${todayMetrics.feedCount}',
-                  yesterdayValue: '${yesterdayMetrics.feedCount}',
-                  showTrend: true,
+                  todayValue: '${currentMetrics.feedCount}',
+                  yesterdayValue: '${previousMetrics.feedCount}',
+                  showTrend: showTrends,
+                  currentLabel: currentLabel,
+                  previousLabel: previousLabel,
                   colorScheme: colorScheme,
                 ),
                 const Divider(height: 24),
                 _ComparisonRow(
                   label: l10n.statisticsVolume,
-                  todayValue: '${todayMetrics.totalMl}ml',
-                  yesterdayValue: '${yesterdayMetrics.totalMl}ml',
-                  showTrend: true,
+                  todayValue: '${currentMetrics.totalMl}ml',
+                  yesterdayValue: '${previousMetrics.totalMl}ml',
+                  showTrend: showTrends,
+                  currentLabel: currentLabel,
+                  previousLabel: previousLabel,
                   colorScheme: colorScheme,
                 ),
                 const Divider(height: 24),
                 _ComparisonRow(
                   label: l10n.statisticsAveragePerFeed,
-                  todayValue: todayMetrics.averageMl > 0
-                      ? '${todayMetrics.averageMl.toStringAsFixed(0)}ml'
+                  todayValue: currentMetrics.averageMl > 0
+                      ? '${currentMetrics.averageMl.toStringAsFixed(0)}ml'
                       : '--',
-                  yesterdayValue: yesterdayMetrics.averageMl > 0
-                      ? '${yesterdayMetrics.averageMl.toStringAsFixed(0)}ml'
+                  yesterdayValue: previousMetrics.averageMl > 0
+                      ? '${previousMetrics.averageMl.toStringAsFixed(0)}ml'
                       : '--',
-                  showTrend: todayMetrics.averageMl > 0 && yesterdayMetrics.averageMl > 0,
+                  showTrend: showTrends &&
+                      currentMetrics.averageMl > 0 &&
+                      previousMetrics.averageMl > 0,
+                  currentLabel: currentLabel,
+                  previousLabel: previousLabel,
                   colorScheme: colorScheme,
                 ),
                 const Divider(height: 24),
                 _ComparisonRow(
                   label: l10n.statisticsDiapersTitle,
-                  todayValue: '${todayMetrics.diaperCount}',
-                  yesterdayValue: '${yesterdayMetrics.diaperCount}',
-                  showTrend: true,
+                  todayValue: '${currentMetrics.diaperCount}',
+                  yesterdayValue: '${previousMetrics.diaperCount}',
+                  showTrend: showTrends,
+                  currentLabel: currentLabel,
+                  previousLabel: previousLabel,
                   colorScheme: colorScheme,
                 ),
               ],
@@ -93,6 +109,8 @@ class _ComparisonRow extends StatelessWidget {
     required this.todayValue,
     required this.yesterdayValue,
     required this.showTrend,
+    required this.currentLabel,
+    required this.previousLabel,
     required this.colorScheme,
   });
 
@@ -100,12 +118,13 @@ class _ComparisonRow extends StatelessWidget {
   final String todayValue;
   final String yesterdayValue;
   final bool showTrend;
+  final String currentLabel;
+  final String previousLabel;
   final ColorScheme colorScheme;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
 
     // Parse numeric values for trend calculation
     final todayNum = _parseNumber(todayValue);
@@ -151,7 +170,7 @@ class _ComparisonRow extends StatelessWidget {
                 ),
               ),
               Text(
-                l10n.statisticsToday,
+                currentLabel,
                 style: theme.textTheme.labelSmall?.copyWith(
                   color: colorScheme.onSurfaceVariant,
                 ),
@@ -176,7 +195,7 @@ class _ComparisonRow extends StatelessWidget {
                 ),
               ),
               Text(
-                l10n.statisticsYesterday,
+                previousLabel,
                 style: theme.textTheme.labelSmall?.copyWith(
                   color: colorScheme.onSurfaceVariant,
                 ),

--- a/lib/presentation/features/statistics/widgets/daily_summary_cards.dart
+++ b/lib/presentation/features/statistics/widgets/daily_summary_cards.dart
@@ -7,10 +7,14 @@ import 'package:pequelog/presentation/features/statistics/widgets/metric_card.da
 class DailySummaryCards extends StatelessWidget {
   const DailySummaryCards({
     required this.metrics,
+    required this.title,
+    this.subtitle,
     super.key,
   });
 
   final DailyMetrics metrics;
+  final String title;
+  final String? subtitle;
 
   @override
   Widget build(BuildContext context) {
@@ -23,11 +27,25 @@ class DailySummaryCards extends StatelessWidget {
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Text(
-            l10n.statisticsDailySummary,
-            style: theme.textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold,
-            ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              if (subtitle != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  subtitle!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ],
           ),
         ),
         const SizedBox(height: 8),

--- a/lib/presentation/features/statistics/widgets/weekly_bar_chart.dart
+++ b/lib/presentation/features/statistics/widgets/weekly_bar_chart.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart' as intl;
 import 'package:pequelog/l10n/app_localizations.dart';
 import 'package:pequelog/presentation/features/statistics/statistics_state.dart';
 
@@ -31,13 +32,16 @@ class WeeklyBarChart extends StatelessWidget {
       (max, item) => item.feedCount > max ? item.feedCount : max,
     );
 
+    final locale = Localizations.localeOf(context);
+    final formatter = intl.DateFormat.Md(locale.toLanguageTag());
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text(
-            l10n.statisticsWeeklyChartTitle,
+            l10n.statisticsTrendChartTitle,
             style: theme.textTheme.titleLarge?.copyWith(
               fontWeight: FontWeight.bold,
             ),
@@ -68,26 +72,44 @@ class WeeklyBarChart extends StatelessWidget {
           height: 220,
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: data.map((dayData) {
-                return Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 4),
-                    child: _BarItem(
-                      dayLabel: dayData.dayLabel,
-                      mlValue: dayData.totalMl,
-                      countValue: dayData.feedCount,
-                      maxMl: maxMl,
-                      maxCount: maxCount,
-                      primaryColor: colorScheme.primary,
-                      secondaryColor: colorScheme.secondary,
-                      isToday: _isToday(dayData.date),
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                const barWidth = 56.0;
+                final contentWidth = barWidth * data.length;
+                return SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minWidth: constraints.maxWidth,
+                    ),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisAlignment: contentWidth <= constraints.maxWidth
+                          ? MainAxisAlignment.spaceEvenly
+                          : MainAxisAlignment.start,
+                      children: data.map((dayData) {
+                        final label = formatter.format(dayData.date);
+                        return SizedBox(
+                          width: barWidth,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 4),
+                            child: _BarItem(
+                              dayLabel: label,
+                              mlValue: dayData.totalMl,
+                              countValue: dayData.feedCount,
+                              maxMl: maxMl,
+                              maxCount: maxCount,
+                              primaryColor: colorScheme.primary,
+                              secondaryColor: colorScheme.secondary,
+                              isToday: _isToday(dayData.date),
+                            ),
+                          ),
+                        );
+                      }).toList(),
                     ),
                   ),
                 );
-              }).toList(),
+              },
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- add segmented filters so caregivers can load statistics for the last 7, 14, 30 days or a custom start date
- recalculate summaries, comparisons, and charts based on the selected period with improved chart scrolling
- expand localization strings to cover the new period controls and labels in English and Spanish

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e3fd4176b08332b2ef2c5a45475d66