### PR TITLE
Fix statistics metrics for decimal feed volumes

### DIFF
--- a/lib/presentation/features/statistics/statistics_state.dart
+++ b/lib/presentation/features/statistics/statistics_state.dart
@@ -29,7 +29,7 @@ extension on StatisticsRange {
 /// Data class for daily statistics metrics
 class DailyMetrics {
   final int feedCount;
-  final int totalMl;
+  final double totalMl;
   final double averageMl;
   final int diaperCount;
   final int urineCount;
@@ -56,8 +56,8 @@ class DailyMetrics {
 
   static const empty = DailyMetrics(
     feedCount: 0,
-    totalMl: 0,
-    averageMl: 0,
+    totalMl: 0.0,
+    averageMl: 0.0,
     diaperCount: 0,
     urineCount: 0,
     fecesCount: 0,
@@ -70,7 +70,7 @@ class DailyMetrics {
 class WeeklyData {
   final DateTime date;
   final int feedCount;
-  final int totalMl;
+  final double totalMl;
   final String dayLabel;
 
   const WeeklyData({
@@ -249,7 +249,7 @@ class StatisticsState extends ChangeNotifier {
     if (actions.isEmpty) return DailyMetrics.empty;
 
     int feedCount = 0;
-    int totalMl = 0;
+    double totalMl = 0;
     int diaperCount = 0;
     int urineCount = 0;
     int fecesCount = 0;
@@ -263,9 +263,9 @@ class StatisticsState extends ChangeNotifier {
         case BabyActionKind.feed:
           feedCount++;
           feedActions.add(action);
-          final amountMl = action.details['amountMl'] as int?;
-          if (amountMl != null) {
-            totalMl += amountMl;
+          final amountMl = action.details['amountMl'];
+          if (amountMl is num) {
+            totalMl += amountMl.toDouble();
           }
           break;
 
@@ -363,14 +363,14 @@ class StatisticsState extends ChangeNotifier {
 
     weeklyMap.forEach((date, dayActions) {
       int feedCount = 0;
-      int totalMl = 0;
+      double totalMl = 0;
 
       for (final action in dayActions) {
         if (action.kind == BabyActionKind.feed) {
           feedCount++;
-          final amountMl = action.details['amountMl'] as int?;
-          if (amountMl != null) {
-            totalMl += amountMl;
+          final amountMl = action.details['amountMl'];
+          if (amountMl is num) {
+            totalMl += amountMl.toDouble();
           }
         }
       }

--- a/lib/presentation/features/statistics/widgets/comparison_widget.dart
+++ b/lib/presentation/features/statistics/widgets/comparison_widget.dart
@@ -61,8 +61,8 @@ class ComparisonWidget extends StatelessWidget {
                 const Divider(height: 24),
                 _ComparisonRow(
                   label: l10n.statisticsVolume,
-                  todayValue: '${currentMetrics.totalMl}ml',
-                  yesterdayValue: '${previousMetrics.totalMl}ml',
+                  todayValue: '${_formatMl(currentMetrics.totalMl)}ml',
+                  yesterdayValue: '${_formatMl(previousMetrics.totalMl)}ml',
                   showTrend: showTrends,
                   currentLabel: currentLabel,
                   previousLabel: previousLabel,
@@ -212,4 +212,10 @@ class _ComparisonRow extends StatelessWidget {
     final cleaned = value.replaceAll(RegExp(r'[^\d.]'), '');
     return double.tryParse(cleaned);
   }
+}
+
+String _formatMl(double value) {
+  return value.truncateToDouble() == value
+      ? value.toStringAsFixed(0)
+      : value.toStringAsFixed(1);
 }

--- a/lib/presentation/features/statistics/widgets/daily_summary_cards.dart
+++ b/lib/presentation/features/statistics/widgets/daily_summary_cards.dart
@@ -70,7 +70,7 @@ class DailySummaryCards extends StatelessWidget {
                   MetricCard(
                     icon: Icons.restaurant,
                     title: l10n.statisticsFeedingTitle,
-                    mainValue: '${metrics.totalMl}',
+                    mainValue: _formatMl(metrics.totalMl),
                     mainLabel: 'ml',
                     secondaryValue: metrics.feedCount > 0
                         ? l10n.statisticsFeedingCount(metrics.feedCount)
@@ -142,4 +142,10 @@ class DailySummaryCards extends StatelessWidget {
       return '${minutes}min';
     }
   }
+}
+
+String _formatMl(double value) {
+  return value.truncateToDouble() == value
+      ? value.toStringAsFixed(0)
+      : value.toStringAsFixed(1);
 }

--- a/lib/presentation/features/statistics/widgets/weekly_bar_chart.dart
+++ b/lib/presentation/features/statistics/widgets/weekly_bar_chart.dart
@@ -23,7 +23,7 @@ class WeeklyBarChart extends StatelessWidget {
     }
 
     // Find max value for scaling
-    final maxMl = data.fold<int>(
+    final maxMl = data.fold<double>(
       0,
       (max, item) => item.totalMl > max ? item.totalMl : max,
     );
@@ -173,9 +173,9 @@ class _BarItem extends StatelessWidget {
   });
 
   final String dayLabel;
-  final int mlValue;
+  final double mlValue;
   final int countValue;
-  final int maxMl;
+  final double maxMl;
   final int maxCount;
   final Color primaryColor;
   final Color secondaryColor;
@@ -202,7 +202,7 @@ class _BarItem extends StatelessWidget {
             children: [
               if (mlValue > 0)
                 Text(
-                  '${mlValue}ml',
+                  '${_formatMl(mlValue)}ml',
                   style: theme.textTheme.labelSmall?.copyWith(
                     fontSize: 10,
                     fontWeight: FontWeight.w600,
@@ -262,4 +262,10 @@ class _BarItem extends StatelessWidget {
       ],
     );
   }
+}
+
+String _formatMl(double value) {
+  return value.truncateToDouble() == value
+      ? value.toStringAsFixed(0)
+      : value.toStringAsFixed(1);
 }

--- a/test/unit/state/statistics_state_test.dart
+++ b/test/unit/state/statistics_state_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pequelog/domain/baby_actions/entities/baby_action.dart';
+import 'package:pequelog/domain/baby_actions/entities/baby_action_draft.dart';
+import 'package:pequelog/domain/baby_actions/entities/baby_action_kind.dart';
+import 'package:pequelog/domain/baby_actions/repositories/baby_action_repository.dart';
+import 'package:pequelog/presentation/features/statistics/statistics_state.dart';
+
+class _FakeBabyActionRepository implements BabyActionRepository {
+  _FakeBabyActionRepository(this._actions);
+
+  final List<BabyAction> _actions;
+
+  @override
+  Future<List<BabyAction>> fetchFilteredActions(
+    int babyId, {
+    List<BabyActionKind>? kinds,
+    DateTime? startDate,
+    DateTime? endDate,
+    int limit = 100,
+    int offset = 0,
+  }) async {
+    return _actions.where((action) {
+      if (action.babyId != babyId) {
+        return false;
+      }
+      if (kinds != null && kinds.isNotEmpty && !kinds.contains(action.kind)) {
+        return false;
+      }
+      if (startDate != null && action.occurredAt.isBefore(startDate)) {
+        return false;
+      }
+      if (endDate != null && action.occurredAt.isAfter(endDate)) {
+        return false;
+      }
+      return true;
+    }).toList(growable: false);
+  }
+
+  @override
+  Future<BabyAction> logAction(BabyActionDraft draft) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<BabyAction>> fetchRecentActions(int babyId, {int limit = 10}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BabyAction> updateAction({
+    required int id,
+    required DateTime occurredAt,
+    String? notes,
+    required Map<String, Object?> details,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> deleteAction(int id) {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  group('StatisticsState', () {
+    test('accumulates feed volume stored as double values', () async {
+      final now = DateTime.now();
+      final repository = _FakeBabyActionRepository([
+        BabyAction(
+          id: 1,
+          babyId: 1,
+          kind: BabyActionKind.feed,
+          occurredAt: now.subtract(const Duration(hours: 1)),
+          notes: null,
+          details: const <String, Object?>{'amountMl': 80.5},
+        ),
+        BabyAction(
+          id: 2,
+          babyId: 1,
+          kind: BabyActionKind.feed,
+          occurredAt: now.subtract(const Duration(hours: 3)),
+          notes: null,
+          details: const <String, Object?>{'amountMl': 95},
+        ),
+      ]);
+
+      final state = StatisticsState(
+        repository: repository,
+        babyId: '1',
+      );
+
+      await state.reload();
+
+      expect(state.currentPeriodMetrics.feedCount, 2);
+      expect(state.currentPeriodMetrics.totalMl, closeTo(175.5, 0.001));
+      expect(state.currentPeriodMetrics.averageMl, closeTo(87.75, 0.001));
+
+      expect(state.weeklyData, isNotEmpty);
+      expect(state.weeklyData.first.totalMl, closeTo(95, 0.001));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- handle feeding amounts stored as decimal values when computing statistics
- update statistics widgets to format milliliter totals without crashing on doubles
- add a unit test covering StatisticsState with fractional feed data

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68e4046860508332adbe08ff51c2c941