### PR TITLE
Fix statistics summary layout overflow

### DIFF
--- a/lib/presentation/features/statistics/statistics_screen.dart
+++ b/lib/presentation/features/statistics/statistics_screen.dart
@@ -138,19 +138,43 @@ class _StatisticsFilterBar extends StatelessWidget {
             segments: [
               ButtonSegment(
                 value: StatisticsRange.last7Days,
-                label: Text(l10n.statisticsRangeLast7Days),
+                label: Tooltip(
+                  message: l10n.statisticsRangeLast7Days,
+                  child: const Icon(
+                    Icons.calendar_view_week_outlined,
+                    size: 20,
+                  ),
+                ),
               ),
               ButtonSegment(
                 value: StatisticsRange.last14Days,
-                label: Text(l10n.statisticsRangeLast14Days),
+                label: Tooltip(
+                  message: l10n.statisticsRangeLast14Days,
+                  child: const Icon(
+                    Icons.calendar_view_month_outlined,
+                    size: 20,
+                  ),
+                ),
               ),
               ButtonSegment(
                 value: StatisticsRange.last30Days,
-                label: Text(l10n.statisticsRangeLast30Days),
+                label: Tooltip(
+                  message: l10n.statisticsRangeLast30Days,
+                  child: const Icon(
+                    Icons.calendar_today_outlined,
+                    size: 20,
+                  ),
+                ),
               ),
               ButtonSegment(
                 value: StatisticsRange.custom,
-                label: Text(l10n.statisticsRangeCustom),
+                label: Tooltip(
+                  message: l10n.statisticsRangeCustom,
+                  child: const Icon(
+                    Icons.edit_calendar_outlined,
+                    size: 20,
+                  ),
+                ),
               ),
             ],
             selected: <StatisticsRange>{state.selectedRange},

--- a/lib/presentation/features/statistics/widgets/daily_summary_cards.dart
+++ b/lib/presentation/features/statistics/widgets/daily_summary_cards.dart
@@ -55,8 +55,9 @@ class DailySummaryCards extends StatelessWidget {
           child: LayoutBuilder(
             builder: (context, constraints) {
               // Responsive: 2 columns on narrow screens, 4 on wide screens
-              final crossAxisCount = constraints.maxWidth > 600 ? 4 : 2;
-              final childAspectRatio = constraints.maxWidth > 600 ? 1.0 : 1.2;
+              final isWide = constraints.maxWidth > 600;
+              final crossAxisCount = isWide ? 4 : 2;
+              final childAspectRatio = isWide ? 1.1 : 0.9;
 
               return GridView.count(
                 crossAxisCount: crossAxisCount,

--- a/lib/presentation/features/statistics/widgets/metric_card.dart
+++ b/lib/presentation/features/statistics/widgets/metric_card.dart
@@ -63,9 +63,10 @@ class MetricCard extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             // Main metric
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              textBaseline: TextBaseline.alphabetic,
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              crossAxisAlignment: WrapCrossAlignment.center,
               children: [
                 Text(
                   mainValue,
@@ -74,7 +75,6 @@ class MetricCard extends StatelessWidget {
                     color: colorScheme.onSurface,
                   ),
                 ),
-                const SizedBox(width: 8),
                 Text(
                   mainLabel,
                   style: theme.textTheme.bodyMedium?.copyWith(
@@ -91,6 +91,7 @@ class MetricCard extends StatelessWidget {
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: colorScheme.onSurfaceVariant,
                 ),
+                softWrap: true,
               ),
             ],
           ],


### PR DESCRIPTION
## Summary
- adjust the daily summary grid proportions to give cards enough height and avoid overflow
- update metric cards to wrap their main and secondary text for better responsiveness
- replace the statistics range text segments with icon-based controls and tooltips

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e40f2e4e1883329837ed050a24289c